### PR TITLE
Add doc structs

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/tfsec/tfsec/internal/app/tfsec/debug"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/formatters"
 
 	"github.com/liamg/tml"
@@ -36,6 +38,7 @@ func init() {
 	rootCmd.Flags().StringSliceVar(&excludeDirectories, "exclude-dir", []string{}, "Exclude a directory from the scan. You can use this flag multiple times to exclude further directories.")
 	rootCmd.Flags().StringVar(&tfvarsPath, "tfvars-file", tfvarsPath, "Path to .tfvars file")
 	rootCmd.Flags().StringVar(&outputFlag, "out", outputFlag, "Set output file")
+	rootCmd.Flags().BoolVar(&debug.Enabled, "verbose", debug.Enabled, "Enable verbose logging")
 }
 
 func main() {
@@ -52,6 +55,7 @@ var rootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 
 		if disableColours {
+			debug.Log("Disabled formatting.")
 			tml.DisableFormatting()
 		}
 
@@ -116,12 +120,14 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
+		debug.Log("Starting parser...")
 		blocks, err := parser.New().ParseDirectory(dir, absoluteExcludes, tfvarsPath)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
 
+		debug.Log("Starting scanner...")
 		results := scanner.New().Scan(blocks, excludedChecksList)
 		if err := formatter(outputFile, results); err != nil {
 			fmt.Println(err)

--- a/internal/app/tfsec/checks/aws_api_gateway_domain_name_missing_security_policy.go
+++ b/internal/app/tfsec/checks/aws_api_gateway_domain_name_missing_security_policy.go
@@ -11,12 +11,25 @@ import (
 // AWSApiGatewayDomainNameOutdatedSecurityPolicy See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSApiGatewayDomainNameOutdatedSecurityPolicy scanner.RuleID = "AWS025"
 const AWSApiGatewayDomainNameOutdatedSecurityPolicyDescription scanner.RuleSummary = "API Gateway domain name uses outdated SSL/TLS protocols."
+const AWSApiGatewayDomainNameOutdatedSecurityPolicyExplanation = `
+
+`
+const AWSApiGatewayDomainNameOutdatedSecurityPolicyBadExample = `
+
+`
+const AWSApiGatewayDomainNameOutdatedSecurityPolicyGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSApiGatewayDomainNameOutdatedSecurityPolicy,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSApiGatewayDomainNameOutdatedSecurityPolicyDescription,
+            Explanation: AWSApiGatewayDomainNameOutdatedSecurityPolicyExplanation,
+            BadExample:  AWSApiGatewayDomainNameOutdatedSecurityPolicyBadExample,
+            GoodExample: AWSApiGatewayDomainNameOutdatedSecurityPolicyGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_bucket_logging.go
+++ b/internal/app/tfsec/checks/aws_bucket_logging.go
@@ -11,12 +11,25 @@ import (
 // AWSNoBucketLogging See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSNoBucketLogging scanner.RuleID = "AWS002"
 const AWSNoBucketLoggingDescription scanner.RuleSummary = "S3 Bucket does not have logging enabled."
+const AWSNoBucketLoggingExplanation = `
+
+`
+const AWSNoBucketLoggingBadExample = `
+
+`
+const AWSNoBucketLoggingGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSNoBucketLogging,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSNoBucketLoggingDescription,
+            Explanation: AWSNoBucketLoggingExplanation,
+            BadExample:  AWSNoBucketLoggingBadExample,
+            GoodExample: AWSNoBucketLoggingGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_classic.go
+++ b/internal/app/tfsec/checks/aws_classic.go
@@ -11,12 +11,25 @@ import (
 // AWSClassicUsage See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSClassicUsage scanner.RuleID = "AWS003"
 const AWSClassicUsageDescription scanner.RuleSummary = "AWS Classic resource usage."
+const AWSClassicUsageExplanation = `
+
+`
+const AWSClassicUsageBadExample = `
+
+`
+const AWSClassicUsageGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSClassicUsage,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSClassicUsageDescription,
+            Explanation: AWSClassicUsageExplanation,
+            BadExample:  AWSClassicUsageBadExample,
+            GoodExample: AWSClassicUsageGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_cloudfront_has_a_waf.go
+++ b/internal/app/tfsec/checks/aws_cloudfront_has_a_waf.go
@@ -10,12 +10,25 @@ import (
 // AWSCloudFrontDoesNotHaveAWaf See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSCloudFrontDoesNotHaveAWaf scanner.RuleID = "AWS045"
 const AWSCloudFrontDoesNotHaveAWafDescription scanner.RuleSummary = "CloudFront distribution does not have a WAF in front."
+const AWSCloudFrontDoesNotHaveAWafExplanation = `
+
+`
+const AWSCloudFrontDoesNotHaveAWafBadExample = `
+
+`
+const AWSCloudFrontDoesNotHaveAWafGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSCloudFrontDoesNotHaveAWaf,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSCloudFrontDoesNotHaveAWafDescription,
+            Explanation: AWSCloudFrontDoesNotHaveAWafExplanation,
+            BadExample:  AWSCloudFrontDoesNotHaveAWafBadExample,
+            GoodExample: AWSCloudFrontDoesNotHaveAWafGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_cloudfront_outdated_protocol.go
+++ b/internal/app/tfsec/checks/aws_cloudfront_outdated_protocol.go
@@ -11,12 +11,25 @@ import (
 // AWSCloudFrontOutdatedProtocol See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSCloudFrontOutdatedProtocol scanner.RuleID = "AWS021"
 const AWSCloudFrontOutdatedProtocolDescription scanner.RuleSummary = "CloudFront distribution uses outdated SSL/TSL protocols."
+const AWSCloudFrontOutdatedProtocolExplanation = `
+
+`
+const AWSCloudFrontOutdatedProtocolBadExample = `
+
+`
+const AWSCloudFrontOutdatedProtocolGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSCloudFrontOutdatedProtocol,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSCloudFrontOutdatedProtocolDescription,
+            Explanation: AWSCloudFrontOutdatedProtocolExplanation,
+            BadExample:  AWSCloudFrontOutdatedProtocolBadExample,
+            GoodExample: AWSCloudFrontOutdatedProtocolGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_ecr_image_scan.go
+++ b/internal/app/tfsec/checks/aws_ecr_image_scan.go
@@ -13,12 +13,25 @@ import (
 // AWSEcrImageScanNotEnabled See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSEcrImageScanNotEnabled scanner.RuleID = "AWS023"
 const AWSEcrImageScanNotEnabledDescription scanner.RuleSummary = "ECR repository has image scans disabled."
+const AWSEcrImageScanNotEnabledExplanation = `
+
+`
+const AWSEcrImageScanNotEnabledBadExample = `
+
+`
+const AWSEcrImageScanNotEnabledGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSEcrImageScanNotEnabled,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSEcrImageScanNotEnabledDescription,
+            Explanation: AWSEcrImageScanNotEnabledExplanation,
+            BadExample:  AWSEcrImageScanNotEnabledBadExample,
+            GoodExample: AWSEcrImageScanNotEnabledGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_http.go
+++ b/internal/app/tfsec/checks/aws_http.go
@@ -12,12 +12,25 @@ import (
 // AWSPlainHTTP See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSPlainHTTP scanner.RuleID = "AWS004"
 const AWSPlainHTTPDescription scanner.RuleSummary = "Use of plain HTTP."
+const AWSPlainHTTPExplanation = `
+
+`
+const AWSPlainHTTPBadExample = `
+
+`
+const AWSPlainHTTPGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSPlainHTTP,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSPlainHTTPDescription,
+            Explanation: AWSPlainHTTPExplanation,
+            BadExample:  AWSPlainHTTPBadExample,
+            GoodExample: AWSPlainHTTPGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_iam_password_policy_checks.go
+++ b/internal/app/tfsec/checks/aws_iam_password_policy_checks.go
@@ -13,12 +13,25 @@ import (
 // AWSIAMPasswordReusePrevention See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSIAMPasswordReusePrevention scanner.RuleID = "AWS037"
 const AWSIAMPasswordReusePreventionDescription scanner.RuleSummary = "IAM Password policy should prevent password reuse."
+const AWSIAMPasswordReusePreventionExplanation = `
+
+`
+const AWSIAMPasswordReusePreventionBadExample = `
+
+`
+const AWSIAMPasswordReusePreventionGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSIAMPasswordReusePrevention,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSIAMPasswordReusePreventionDescription,
+            Explanation: AWSIAMPasswordReusePreventionExplanation,
+            BadExample:  AWSIAMPasswordReusePreventionBadExample,
+            GoodExample: AWSIAMPasswordReusePreventionGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_iam_policy_document.go
+++ b/internal/app/tfsec/checks/aws_iam_policy_document.go
@@ -11,12 +11,25 @@ import (
 // AWSIamPolicyWildcardActions See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSIamPolicyWildcardActions scanner.RuleID = "AWS046"
 const AWSIamPolicyWildcardActionsDescription scanner.RuleSummary = "AWS IAM policy document has wildcard action statement."
+const AWSIamPolicyWildcardActionsExplanation = `
+
+`
+const AWSIamPolicyWildcardActionsBadExample = `
+
+`
+const AWSIamPolicyWildcardActionsGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSIamPolicyWildcardActions,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSIamPolicyWildcardActionsDescription,
+            Explanation: AWSIamPolicyWildcardActionsExplanation,
+            BadExample:  AWSIamPolicyWildcardActionsBadExample,
+            GoodExample: AWSIamPolicyWildcardActionsGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"data"},

--- a/internal/app/tfsec/checks/aws_missing_description_in_security_group.go
+++ b/internal/app/tfsec/checks/aws_missing_description_in_security_group.go
@@ -12,12 +12,25 @@ import (
 // AWSNoDescriptionInSecurityGroup See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSNoDescriptionInSecurityGroup scanner.RuleID = "AWS018"
 const AWSNoDescriptionInSecurityGroupDescription scanner.RuleSummary = "Missing description for security group/security group rule."
+const AWSNoInSecurityGroupExplanation = `
+
+`
+const AWSNoInSecurityGroupBadExample = `
+
+`
+const AWSNoInSecurityGroupGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSNoDescriptionInSecurityGroup,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSNoDescriptionInSecurityGroupDescription,
+            Explanation: AWSNoInSecurityGroupExplanation,
+            BadExample:  AWSNoInSecurityGroupBadExample,
+            GoodExample: AWSNoInSecurityGroupGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_no_kms_key_autorotate.go
+++ b/internal/app/tfsec/checks/aws_no_kms_key_autorotate.go
@@ -12,12 +12,25 @@ import (
 // AWSNoKMSAutoRotate See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSNoKMSAutoRotate scanner.RuleID = "AWS019"
 const AWSNoKMSAutoRotateDescription scanner.RuleSummary = "A KMS key is not configured to auto-rotate."
+const AWSNoKMSAutoRotateExplanation = `
+
+`
+const AWSNoKMSAutoRotateBadExample = `
+
+`
+const AWSNoKMSAutoRotateGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSNoKMSAutoRotate,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSNoKMSAutoRotateDescription,
+            Explanation: AWSNoKMSAutoRotateExplanation,
+            BadExample:  AWSNoKMSAutoRotateBadExample,
+            GoodExample: AWSNoKMSAutoRotateGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_not_internal.go
+++ b/internal/app/tfsec/checks/aws_not_internal.go
@@ -13,12 +13,25 @@ import (
 // AWSExternallyExposedLoadBalancer See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSExternallyExposedLoadBalancer scanner.RuleID = "AWS005"
 const AWSExternallyExposedLoadBalancerDescription scanner.RuleSummary = "Load balancer is exposed to the internet."
+const AWSExternallyExposedLoadBalancerExplanation = `
+
+`
+const AWSExternallyExposedLoadBalancerBadExample = `
+
+`
+const AWSExternallyExposedLoadBalancerGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSExternallyExposedLoadBalancer,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSExternallyExposedLoadBalancerDescription,
+            Explanation: AWSExternallyExposedLoadBalancerExplanation,
+            BadExample:  AWSExternallyExposedLoadBalancerBadExample,
+            GoodExample: AWSExternallyExposedLoadBalancerGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_open_security_group_rules.go
+++ b/internal/app/tfsec/checks/aws_open_security_group_rules.go
@@ -14,6 +14,15 @@ import (
 // AWSOpenIngressSecurityGroupRule See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSOpenIngressSecurityGroupRule scanner.RuleID = "AWS006"
 const AWSOpenIngressSecurityGroupRuleDescription scanner.RuleSummary = "An ingress security group rule allows traffic from `/0`."
+const AWSOpenIngressSecurityGroupRuleExplanation = `
+
+`
+const AWSOpenIngressSecurityGroupRuleBadExample = `
+
+`
+const AWSOpenIngressSecurityGroupRuleGoodExample = `
+
+`
 
 // AWSOpenEgressSecurityGroupRule See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSOpenEgressSecurityGroupRule scanner.RuleID = "AWS007"
@@ -24,6 +33,10 @@ func init() {
 		Code: AWSOpenIngressSecurityGroupRule,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSOpenIngressSecurityGroupRuleDescription,
+            Explanation: AWSOpenIngressSecurityGroupRuleExplanation,
+            BadExample:  AWSOpenIngressSecurityGroupRuleBadExample,
+            GoodExample: AWSOpenIngressSecurityGroupRuleGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_open_security_groups.go
+++ b/internal/app/tfsec/checks/aws_open_security_groups.go
@@ -12,6 +12,15 @@ import (
 // AWSOpenIngressSecurityGroupInlineRule See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSOpenIngressSecurityGroupInlineRule scanner.RuleID = "AWS008"
 const AWSOpenIngressSecurityGroupInlineRuleDescription scanner.RuleSummary = "An inline ingress security group rule allows traffic from `/0`."
+const AWSOpenIngressSecurityGroupInlineRuleExplanation = `
+
+`
+const AWSOpenIngressSecurityGroupInlineRuleBadExample = `
+
+`
+const AWSOpenIngressSecurityGroupInlineRuleGoodExample = `
+
+`
 
 // AWSOpenEgressSecurityGroupInlineRule See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSOpenEgressSecurityGroupInlineRule scanner.RuleID = "AWS009"
@@ -22,6 +31,10 @@ func init() {
 		Code: AWSOpenIngressSecurityGroupInlineRule,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSOpenIngressSecurityGroupInlineRuleDescription,
+            Explanation: AWSOpenIngressSecurityGroupInlineRuleExplanation,
+            BadExample:  AWSOpenIngressSecurityGroupInlineRuleBadExample,
+            GoodExample: AWSOpenIngressSecurityGroupInlineRuleGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_oudated_tls_policy_elasticsearch_domain_endpoint.go
+++ b/internal/app/tfsec/checks/aws_oudated_tls_policy_elasticsearch_domain_endpoint.go
@@ -13,12 +13,25 @@ import (
 // https://github.com/tfsec/tfsec#included-checks for check info
 const AWSOutdatedTLSPolicyElasticsearchDomainEndpoint scanner.RuleID = "AWS034"
 const AWSOutdatedTLSPolicyElasticsearchDomainEndpointDescription scanner.RuleSummary = "Elasticsearch domain endpoint is using outdated TLS policy."
+const AWSOutdatedTLSPolicyElasticsearchDomainEndpointExplanation = `
+
+`
+const AWSOutdatedTLSPolicyElasticsearchDomainEndpointBadExample = `
+
+`
+const AWSOutdatedTLSPolicyElasticsearchDomainEndpointGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSOutdatedTLSPolicyElasticsearchDomainEndpoint,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSOutdatedTLSPolicyElasticsearchDomainEndpointDescription,
+            Explanation: AWSOutdatedTLSPolicyElasticsearchDomainEndpointExplanation,
+            BadExample:  AWSOutdatedTLSPolicyElasticsearchDomainEndpointBadExample,
+            GoodExample: AWSOutdatedTLSPolicyElasticsearchDomainEndpointGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_outdated_ssl.go
+++ b/internal/app/tfsec/checks/aws_outdated_ssl.go
@@ -13,6 +13,15 @@ import (
 // AWSOutdatedSSLPolicy See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSOutdatedSSLPolicy scanner.RuleID = "AWS010"
 const AWSOutdatedSSLPolicyDescription scanner.RuleSummary = "An outdated SSL policy is in use by a load balancer."
+const AWSOutdatedSSLPolicyExplanation = `
+
+`
+const AWSOutdatedSSLPolicyBadExample = `
+
+`
+const AWSOutdatedSSLPolicyGoodExample = `
+
+`
 
 var outdatedSSLPolicies = []string{
 	"ELBSecurityPolicy-2015-05",
@@ -26,6 +35,10 @@ func init() {
 		Code: AWSOutdatedSSLPolicy,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSOutdatedSSLPolicyDescription,
+            Explanation: AWSOutdatedSSLPolicyExplanation,
+            BadExample:  AWSOutdatedSSLPolicyBadExample,
+            GoodExample: AWSOutdatedSSLPolicyGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_plaintext_node_to_node_elasticsearch_traffic.go
+++ b/internal/app/tfsec/checks/aws_plaintext_node_to_node_elasticsearch_traffic.go
@@ -12,12 +12,25 @@ import (
 // AWSPlaintextNodeToNodeElasticsearchTraffic See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSPlaintextNodeToNodeElasticsearchTraffic scanner.RuleID = "AWS032"
 const AWSPlaintextNodeToNodeElasticsearchTrafficDescription scanner.RuleSummary = "Elasticsearch domain uses plaintext traffic for node to node communication."
+const AWSPlaintextNodeToNodeElasticsearchTrafficExplanation = `
+
+`
+const AWSPlaintextNodeToNodeElasticsearchTrafficBadExample = `
+
+`
+const AWSPlaintextNodeToNodeElasticsearchTrafficGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSPlaintextNodeToNodeElasticsearchTraffic,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSPlaintextNodeToNodeElasticsearchTrafficDescription,
+            Explanation: AWSPlaintextNodeToNodeElasticsearchTrafficExplanation,
+            BadExample:  AWSPlaintextNodeToNodeElasticsearchTrafficBadExample,
+            GoodExample: AWSPlaintextNodeToNodeElasticsearchTrafficGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_provider.go
+++ b/internal/app/tfsec/checks/aws_provider.go
@@ -13,12 +13,25 @@ import (
 // AWSProviderHasAccessCredentials See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSProviderHasAccessCredentials scanner.RuleID = "AWS044"
 const AWSProviderHasAccessCredentialsDescription scanner.RuleSummary = "AWS provider has access credentials specified."
+const AWSProviderHasAccessCredentialsExplanation = `
+
+`
+const AWSProviderHasAccessCredentialsBadExample = `
+
+`
+const AWSProviderHasAccessCredentialsGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSProviderHasAccessCredentials,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSProviderHasAccessCredentialsDescription,
+            Explanation: AWSProviderHasAccessCredentialsExplanation,
+            BadExample:  AWSProviderHasAccessCredentialsBadExample,
+            GoodExample: AWSProviderHasAccessCredentialsGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"provider"},

--- a/internal/app/tfsec/checks/aws_public.go
+++ b/internal/app/tfsec/checks/aws_public.go
@@ -13,12 +13,25 @@ import (
 // AWSPubliclyAccessibleResource See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSPubliclyAccessibleResource scanner.RuleID = "AWS011"
 const AWSPubliclyAccessibleResourceDescription scanner.RuleSummary = "A resource is marked as publicly accessible."
+const AWSPubliclyAccessibleResourceExplanation = `
+
+`
+const AWSPubliclyAccessibleResourceBadExample = `
+
+`
+const AWSPubliclyAccessibleResourceGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSPubliclyAccessibleResource,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSPubliclyAccessibleResourceDescription,
+            Explanation: AWSPubliclyAccessibleResourceExplanation,
+            BadExample:  AWSPubliclyAccessibleResourceBadExample,
+            GoodExample: AWSPubliclyAccessibleResourceGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_public_ip.go
+++ b/internal/app/tfsec/checks/aws_public_ip.go
@@ -13,12 +13,25 @@ import (
 // AWSResourceHasPublicIP See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSResourceHasPublicIP scanner.RuleID = "AWS012"
 const AWSResourceHasPublicIPDescription scanner.RuleSummary = "A resource has a public IP address."
+const AWSResourceHasPublicIPExplanation = `
+
+`
+const AWSResourceHasPublicIPBadExample = `
+
+`
+const AWSResourceHasPublicIPGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSResourceHasPublicIP,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSResourceHasPublicIPDescription,
+            Explanation: AWSResourceHasPublicIPExplanation,
+            BadExample:  AWSResourceHasPublicIPBadExample,
+            GoodExample: AWSResourceHasPublicIPGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_task_definition_includes_sensitive_data.go
+++ b/internal/app/tfsec/checks/aws_task_definition_includes_sensitive_data.go
@@ -16,12 +16,25 @@ import (
 // AWSTaskDefinitionWithSensitiveEnvironmentVariables See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSTaskDefinitionWithSensitiveEnvironmentVariables scanner.RuleID = "AWS013"
 const AWSTaskDefinitionWithSensitiveEnvironmentVariablesDescription scanner.RuleSummary = "Task definition defines sensitive environment variable(s)."
+const AWSTaskDefinitionWithSensitiveEnvironmentVariablesExplanation = `
+
+`
+const AWSTaskDefinitionWithSensitiveEnvironmentVariablesBadExample = `
+
+`
+const AWSTaskDefinitionWithSensitiveEnvironmentVariablesGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSTaskDefinitionWithSensitiveEnvironmentVariables,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSTaskDefinitionWithSensitiveEnvironmentVariablesDescription,
+            Explanation: AWSTaskDefinitionWithSensitiveEnvironmentVariablesExplanation,
+            BadExample:  AWSTaskDefinitionWithSensitiveEnvironmentVariablesBadExample,
+            GoodExample: AWSTaskDefinitionWithSensitiveEnvironmentVariablesGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_unencrypted_at_rest_elasticache_replication_group.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_at_rest_elasticache_replication_group.go
@@ -11,12 +11,25 @@ import (
 // AWSUnencryptedAtRestElasticacheReplicationGroup See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSUnencryptedAtRestElasticacheReplicationGroup scanner.RuleID = "AWS035"
 const AWSUnencryptedAtRestElasticacheReplicationGroupDescription scanner.RuleSummary = "Unencrypted Elasticache Replication Group."
+const AWSUnencryptedAtRestElasticacheReplicationGroupExplanation = `
+
+`
+const AWSUnencryptedAtRestElasticacheReplicationGroupBadExample = `
+
+`
+const AWSUnencryptedAtRestElasticacheReplicationGroupGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSUnencryptedAtRestElasticacheReplicationGroup,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSUnencryptedAtRestElasticacheReplicationGroupDescription,
+            Explanation: AWSUnencryptedAtRestElasticacheReplicationGroupExplanation,
+            BadExample:  AWSUnencryptedAtRestElasticacheReplicationGroupBadExample,
+            GoodExample: AWSUnencryptedAtRestElasticacheReplicationGroupGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_unencrypted_block_device.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_block_device.go
@@ -13,12 +13,25 @@ import (
 // AWSLaunchConfigurationWithUnencryptedBlockDevice See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSLaunchConfigurationWithUnencryptedBlockDevice scanner.RuleID = "AWS014"
 const AWSLaunchConfigurationWithUnencryptedBlockDeviceDescription scanner.RuleSummary = "Launch configuration with unencrypted block device."
+const AWSLaunchConfigurationWithUnencryptedBlockDeviceExplanation = `
+
+`
+const AWSLaunchConfigurationWithUnencryptedBlockDeviceBadExample = `
+
+`
+const AWSLaunchConfigurationWithUnencryptedBlockDeviceGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSLaunchConfigurationWithUnencryptedBlockDevice,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSLaunchConfigurationWithUnencryptedBlockDeviceDescription,
+            Explanation: AWSLaunchConfigurationWithUnencryptedBlockDeviceExplanation,
+            BadExample:  AWSLaunchConfigurationWithUnencryptedBlockDeviceBadExample,
+            GoodExample: AWSLaunchConfigurationWithUnencryptedBlockDeviceGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_unencrypted_cloudfront_communications.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_cloudfront_communications.go
@@ -13,12 +13,25 @@ import (
 // AWSUnencryptedCloudFrontCommunications See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSUnencryptedCloudFrontCommunications scanner.RuleID = "AWS020"
 const AWSUnencryptedCloudFrontCommunicationsDescription scanner.RuleSummary = "CloudFront distribution allows unencrypted (HTTP) communications."
+const AWSUnencryptedCloudFrontCommunicationsExplanation = `
+
+`
+const AWSUnencryptedCloudFrontCommunicationsBadExample = `
+
+`
+const AWSUnencryptedCloudFrontCommunicationsGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSUnencryptedCloudFrontCommunications,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSUnencryptedCloudFrontCommunicationsDescription,
+            Explanation: AWSUnencryptedCloudFrontCommunicationsExplanation,
+            BadExample:  AWSUnencryptedCloudFrontCommunicationsBadExample,
+            GoodExample: AWSUnencryptedCloudFrontCommunicationsGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_unencrypted_elasticsearch_domain.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_elasticsearch_domain.go
@@ -12,12 +12,25 @@ import (
 // AWSUnencryptedElasticsearchDomain See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSUnencryptedElasticsearchDomain scanner.RuleID = "AWS031"
 const AWSUnencryptedElasticsearchDomainDescription scanner.RuleSummary = "Elasticsearch domain isn't encrypted at rest."
+const AWSUnencryptedElasticsearchDomainExplanation = `
+
+`
+const AWSUnencryptedElasticsearchDomainBadExample = `
+
+`
+const AWSUnencryptedElasticsearchDomainGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSUnencryptedElasticsearchDomain,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSUnencryptedElasticsearchDomainDescription,
+            Explanation: AWSUnencryptedElasticsearchDomainExplanation,
+            BadExample:  AWSUnencryptedElasticsearchDomainBadExample,
+            GoodExample: AWSUnencryptedElasticsearchDomainGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_unencrypted_in_transit_elasticache_replication_group.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_in_transit_elasticache_replication_group.go
@@ -11,12 +11,25 @@ import (
 // AWSUnencryptedInTransitElasticacheReplicationGroup See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSUnencryptedInTransitElasticacheReplicationGroup scanner.RuleID = "AWS036"
 const AWSUnencryptedInTransitElasticacheReplicationGroupDescription scanner.RuleSummary = "Elasticache Replication Group uses unencrypted traffic."
+const AWSUnencryptedInTransitElasticacheReplicationGroupExplanation = `
+
+`
+const AWSUnencryptedInTransitElasticacheReplicationGroupBadExample = `
+
+`
+const AWSUnencryptedInTransitElasticacheReplicationGroupGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSUnencryptedInTransitElasticacheReplicationGroup,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSUnencryptedInTransitElasticacheReplicationGroupDescription,
+            Explanation: AWSUnencryptedInTransitElasticacheReplicationGroupExplanation,
+            BadExample:  AWSUnencryptedInTransitElasticacheReplicationGroupBadExample,
+            GoodExample: AWSUnencryptedInTransitElasticacheReplicationGroupGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_unencrypted_kinesis_streams.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_kinesis_streams.go
@@ -13,12 +13,25 @@ import (
 // AWSUnencryptedKinesisStream See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSUnencryptedKinesisStream scanner.RuleID = "AWS024"
 const AWSUnencryptedKinesisStreamDescription scanner.RuleSummary = "Kinesis stream is unencrypted."
+const AWSUnencryptedKinesisStreamExplanation = `
+
+`
+const AWSUnencryptedKinesisStreamBadExample = `
+
+`
+const AWSUnencryptedKinesisStreamGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSUnencryptedKinesisStream,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSUnencryptedKinesisStreamDescription,
+            Explanation: AWSUnencryptedKinesisStreamExplanation,
+            BadExample:  AWSUnencryptedKinesisStreamBadExample,
+            GoodExample: AWSUnencryptedKinesisStreamGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_unencrypted_msk_broker_transit.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_msk_broker_transit.go
@@ -11,12 +11,25 @@ import (
 // AWSUnencryptedMSKBroker See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSUnencryptedMSKBroker scanner.RuleID = "AWS022"
 const AWSUnencryptedMSKBrokerDescription scanner.RuleSummary = "A MSK cluster allows unencrypted data in transit."
+const AWSUnencryptedMSKBrokerExplanation = `
+
+`
+const AWSUnencryptedMSKBrokerBadExample = `
+
+`
+const AWSUnencryptedMSKBrokerGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSUnencryptedMSKBroker,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSUnencryptedMSKBrokerDescription,
+            Explanation: AWSUnencryptedMSKBrokerExplanation,
+            BadExample:  AWSUnencryptedMSKBrokerBadExample,
+            GoodExample: AWSUnencryptedMSKBrokerGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_unencrypted_s3_bucket.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_s3_bucket.go
@@ -11,12 +11,25 @@ import (
 // AWSUnencryptedS3Bucket See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSUnencryptedS3Bucket scanner.RuleID = "AWS017"
 const AWSUnencryptedS3BucketDescription scanner.RuleSummary = "Unencrypted S3 bucket."
+const AWSUnencryptedS3BucketExplanation = `
+
+`
+const AWSUnencryptedS3BucketBadExample = `
+
+`
+const AWSUnencryptedS3BucketGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSUnencryptedS3Bucket,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSUnencryptedS3BucketDescription,
+            Explanation: AWSUnencryptedS3BucketExplanation,
+            BadExample:  AWSUnencryptedS3BucketBadExample,
+            GoodExample: AWSUnencryptedS3BucketGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_unencrypted_sns_topic.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_sns_topic.go
@@ -13,12 +13,25 @@ import (
 // AWSUnencryptedSNSTopic See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSUnencryptedSNSTopic scanner.RuleID = "AWS016"
 const AWSUnencryptedSNSTopicDescription scanner.RuleSummary = "Unencrypted SNS topic."
+const AWSUnencryptedSNSTopicExplanation = `
+
+`
+const AWSUnencryptedSNSTopicBadExample = `
+
+`
+const AWSUnencryptedSNSTopicGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSUnencryptedSNSTopic,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSUnencryptedSNSTopicDescription,
+            Explanation: AWSUnencryptedSNSTopicExplanation,
+            BadExample:  AWSUnencryptedSNSTopicBadExample,
+            GoodExample: AWSUnencryptedSNSTopicGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_unencrypted_sqs_queue.go
+++ b/internal/app/tfsec/checks/aws_unencrypted_sqs_queue.go
@@ -13,12 +13,25 @@ import (
 // AWSUnencryptedSQSQueue See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSUnencryptedSQSQueue scanner.RuleID = "AWS015"
 const AWSUnencryptedSQSQueueDescription scanner.RuleSummary = "Unencrypted SQS queue."
+const AWSUnencryptedSQSQueueExplanation = `
+
+`
+const AWSUnencryptedSQSQueueBadExample = `
+
+`
+const AWSUnencryptedSQSQueueGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSUnencryptedSQSQueue,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSUnencryptedSQSQueueDescription,
+            Explanation: AWSUnencryptedSQSQueueExplanation,
+            BadExample:  AWSUnencryptedSQSQueueBadExample,
+            GoodExample: AWSUnencryptedSQSQueueGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/aws_unenforced_https_elasticsearch_domain_endpoint.go
+++ b/internal/app/tfsec/checks/aws_unenforced_https_elasticsearch_domain_endpoint.go
@@ -13,12 +13,25 @@ import (
 // https://github.com/tfsec/tfsec#included-checks for check info
 const AWSUnenforcedHTTPSElasticsearchDomainEndpoint scanner.RuleID = "AWS033"
 const AWSUnenforcedHTTPSElasticsearchDomainEndpointDescription scanner.RuleSummary = "Elasticsearch doesn't enforce HTTPS traffic."
+const AWSUnenforcedHTTPSElasticsearchDomainEndpointExplanation = `
+
+`
+const AWSUnenforcedHTTPSElasticsearchDomainEndpointBadExample = `
+
+`
+const AWSUnenforcedHTTPSElasticsearchDomainEndpointGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSUnenforcedHTTPSElasticsearchDomainEndpoint,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AWSUnenforcedHTTPSElasticsearchDomainEndpointDescription,
+            Explanation: AWSUnenforcedHTTPSElasticsearchDomainEndpointExplanation,
+            BadExample:  AWSUnenforcedHTTPSElasticsearchDomainEndpointBadExample,
+            GoodExample: AWSUnenforcedHTTPSElasticsearchDomainEndpointGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/azurerm_open_network_security_rules.go
+++ b/internal/app/tfsec/checks/azurerm_open_network_security_rules.go
@@ -14,6 +14,15 @@ import (
 // AzureOpenInboundNetworkSecurityGroupRule See https://github.com/tfsec/tfsec#included-checks for check info
 const AzureOpenInboundNetworkSecurityGroupRule scanner.RuleID = "AZU001"
 const AzureOpenInboundNetworkSecurityGroupRuleDescription scanner.RuleSummary = "An inbound network security rule allows traffic from `/0`."
+const AzureOpenInboundNetworkSecurityGroupRuleExplanation = `
+
+`
+const AzureOpenInboundNetworkSecurityGroupRuleBadExample = `
+
+`
+const AzureOpenInboundNetworkSecurityGroupRuleGoodExample = `
+
+`
 
 // AzureOpenOutboundNetworkSecurityGroupRule See https://github.com/tfsec/tfsec#included-checks for check info
 const AzureOpenOutboundNetworkSecurityGroupRule scanner.RuleID = "AZU002"
@@ -24,6 +33,10 @@ func init() {
 		Code: AzureOpenInboundNetworkSecurityGroupRule,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AzureOpenInboundNetworkSecurityGroupRuleDescription,
+            Explanation: AzureOpenInboundNetworkSecurityGroupRuleExplanation,
+            BadExample:  AzureOpenInboundNetworkSecurityGroupRuleBadExample,
+            GoodExample: AzureOpenInboundNetworkSecurityGroupRuleGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AzureProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/azurerm_unencrypted_data_lake_store.go
+++ b/internal/app/tfsec/checks/azurerm_unencrypted_data_lake_store.go
@@ -12,12 +12,25 @@ import (
 // AzureUnencryptedDataLakeStore See https://github.com/tfsec/tfsec#included-checks for check info
 const AzureUnencryptedDataLakeStore scanner.RuleID = "AZU004"
 const AzureUnencryptedDataLakeStoreDescription scanner.RuleSummary = "Unencrypted data lake store."
+const AzureUnencryptedDataLakeStoreExplanation = `
+
+`
+const AzureUnencryptedDataLakeStoreBadExample = `
+
+`
+const AzureUnencryptedDataLakeStoreGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AzureUnencryptedDataLakeStore,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AzureUnencryptedDataLakeStoreDescription,
+            Explanation: AzureUnencryptedDataLakeStoreExplanation,
+            BadExample:  AzureUnencryptedDataLakeStoreBadExample,
+            GoodExample: AzureUnencryptedDataLakeStoreGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AzureProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/azurerm_unencrypted_managed_disk.go
+++ b/internal/app/tfsec/checks/azurerm_unencrypted_managed_disk.go
@@ -13,12 +13,25 @@ import (
 // AzureUnencryptedManagedDisk See https://github.com/tfsec/tfsec#included-checks for check info
 const AzureUnencryptedManagedDisk scanner.RuleID = "AZU003"
 const AzureUnencryptedManagedDiskDescription scanner.RuleSummary = "Unencrypted managed disk."
+const AzureUnencryptedManagedDiskExplanation = `
+
+`
+const AzureUnencryptedManagedDiskBadExample = `
+
+`
+const AzureUnencryptedManagedDiskGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AzureUnencryptedManagedDisk,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AzureUnencryptedManagedDiskDescription,
+            Explanation: AzureUnencryptedManagedDiskExplanation,
+            BadExample:  AzureUnencryptedManagedDiskBadExample,
+            GoodExample: AzureUnencryptedManagedDiskGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AzureProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/azurerm_virtual_machine_with_password_authentication.go
+++ b/internal/app/tfsec/checks/azurerm_virtual_machine_with_password_authentication.go
@@ -13,12 +13,25 @@ import (
 // AzureVMWithPasswordAuthentication See https://github.com/tfsec/tfsec#included-checks for check info
 const AzureVMWithPasswordAuthentication scanner.RuleID = "AZU005"
 const AzureVMWithPasswordAuthenticationDescription scanner.RuleSummary = "Password authentication in use instead of SSH keys."
+const AzureVMWithPasswordAuthenticationExplanation = `
+
+`
+const AzureVMWithPasswordAuthenticationBadExample = `
+
+`
+const AzureVMWithPasswordAuthenticationGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AzureVMWithPasswordAuthentication,
 		Documentation: scanner.CheckDocumentation{
 			Summary: AzureVMWithPasswordAuthenticationDescription,
+            Explanation: AzureVMWithPasswordAuthenticationExplanation,
+            BadExample:  AzureVMWithPasswordAuthenticationBadExample,
+            GoodExample: AzureVMWithPasswordAuthenticationGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.AzureProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/generic_sensitive_attributes.go
+++ b/internal/app/tfsec/checks/generic_sensitive_attributes.go
@@ -14,6 +14,15 @@ import (
 // GenericSensitiveAttributes See https://github.com/tfsec/tfsec#included-checks for check info
 const GenericSensitiveAttributes scanner.RuleID = "GEN003"
 const GenericSensitiveAttributesDescription scanner.RuleSummary = "Potentially sensitive data stored in block attribute."
+const GenericSensitiveAttributesExplanation = `
+
+`
+const GenericSensitiveAttributesBadExample = `
+
+`
+const GenericSensitiveAttributesGoodExample = `
+
+`
 
 var sensitiveWhitelist = []struct {
 	Resource  string
@@ -34,6 +43,10 @@ func init() {
 		Code: GenericSensitiveAttributes,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GenericSensitiveAttributesDescription,
+            Explanation: GenericSensitiveAttributesExplanation,
+            BadExample:  GenericSensitiveAttributesBadExample,
+            GoodExample: GenericSensitiveAttributesGoodExample,
+            Links: []string{},
 		},
 		Provider:      scanner.GeneralProvider,
 		RequiredTypes: []string{"resource", "provider", "module"},

--- a/internal/app/tfsec/checks/generic_sensitive_locals.go
+++ b/internal/app/tfsec/checks/generic_sensitive_locals.go
@@ -14,12 +14,25 @@ import (
 // GenericSensitiveLocals See https://github.com/tfsec/tfsec#included-checks for check info
 const GenericSensitiveLocals scanner.RuleID = "GEN002"
 const GenericSensitiveLocalsDescription scanner.RuleSummary = "Potentially sensitive data stored in local value."
+const GenericSensitiveLocalsExplanation = `
+
+`
+const GenericSensitiveLocalsBadExample = `
+
+`
+const GenericSensitiveLocalsGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: GenericSensitiveLocals,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GenericSensitiveLocalsDescription,
+            Explanation: GenericSensitiveLocalsExplanation,
+            BadExample:  GenericSensitiveLocalsBadExample,
+            GoodExample: GenericSensitiveLocalsGoodExample,
+            Links: []string{},
 		},
 		Provider:      scanner.GeneralProvider,
 		RequiredTypes: []string{"locals"},

--- a/internal/app/tfsec/checks/generic_sensitive_variables.go
+++ b/internal/app/tfsec/checks/generic_sensitive_variables.go
@@ -14,12 +14,25 @@ import (
 // GenericSensitiveVariables See https://github.com/tfsec/tfsec#included-checks for check info
 const GenericSensitiveVariables scanner.RuleID = "GEN001"
 const GenericSensitiveVariablesDescription scanner.RuleSummary = "Potentially sensitive data stored in \"default\" value of variable."
+const GenericSensitiveVariablesExplanation = `
+
+`
+const GenericSensitiveVariablesBadExample = `
+
+`
+const GenericSensitiveVariablesGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: GenericSensitiveVariables,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GenericSensitiveVariablesDescription,
+            Explanation: GenericSensitiveVariablesExplanation,
+            BadExample:  GenericSensitiveVariablesBadExample,
+            GoodExample: GenericSensitiveVariablesGoodExample,
+            Links: []string{},
 		},
 		Provider:      scanner.GeneralProvider,
 		RequiredTypes: []string{"variable"},

--- a/internal/app/tfsec/checks/gke_abac_enabled.go
+++ b/internal/app/tfsec/checks/gke_abac_enabled.go
@@ -10,12 +10,25 @@ import (
 // GkeAbacEnabled See https://github.com/tfsec/tfsec#included-checks for check info
 const GkeAbacEnabled scanner.RuleID = "GCP005"
 const GkeAbacEnabledDescription scanner.RuleSummary = "Legacy ABAC permissions are enabled."
+const GkeAbacEnabledExplanation = `
+
+`
+const GkeAbacEnabledBadExample = `
+
+`
+const GkeAbacEnabledGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: GkeAbacEnabled,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GkeAbacEnabledDescription,
+            Explanation: GkeAbacEnabledExplanation,
+            BadExample:  GkeAbacEnabledBadExample,
+            GoodExample: GkeAbacEnabledGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/gke_enforce_psp.go
+++ b/internal/app/tfsec/checks/gke_enforce_psp.go
@@ -11,12 +11,25 @@ import (
 // GkeEnforcePSP See https://github.com/tfsec/tfsec#included-checks for check info
 const GkeEnforcePSP scanner.RuleID = "GCP009"
 const GkeEnforcePSPDescription scanner.RuleSummary = "Pod security policy enforcement not defined."
+const GkeEnforcePSPExplanation = `
+
+`
+const GkeEnforcePSPBadExample = `
+
+`
+const GkeEnforcePSPGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: GkeEnforcePSP,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GkeEnforcePSPDescription,
+            Explanation: GkeEnforcePSPExplanation,
+            BadExample:  GkeEnforcePSPBadExample,
+            GoodExample: GkeEnforcePSPGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/gke_legacy_auth_enabled.go
+++ b/internal/app/tfsec/checks/gke_legacy_auth_enabled.go
@@ -13,12 +13,25 @@ import (
 // GkeLegacyAuthEnabled See https://github.com/tfsec/tfsec#included-checks for check info
 const GkeLegacyAuthEnabled scanner.RuleID = "GCP008"
 const GkeLegacyAuthEnabledDescription scanner.RuleSummary = "Legacy client authentication methods utilized."
+const GkeLegacyAuthEnabledExplanation = `
+
+`
+const GkeLegacyAuthEnabledBadExample = `
+
+`
+const GkeLegacyAuthEnabledGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: GkeLegacyAuthEnabled,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GkeLegacyAuthEnabledDescription,
+            Explanation: GkeLegacyAuthEnabledExplanation,
+            BadExample:  GkeLegacyAuthEnabledBadExample,
+            GoodExample: GkeLegacyAuthEnabledGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/gke_legacy_metadata_endpoints.go
+++ b/internal/app/tfsec/checks/gke_legacy_metadata_endpoints.go
@@ -13,12 +13,25 @@ import (
 // GkeLegacyMetadataEndpoints See https://github.com/tfsec/tfsec#included-checks for check info
 const GkeLegacyMetadataEndpoints scanner.RuleID = "GCP007"
 const GkeLegacyMetadataEndpointsDescription scanner.RuleSummary = "Legacy metadata endpoints enabled."
+const GkeLegacyMetadataEndpointsExplanation = `
+
+`
+const GkeLegacyMetadataEndpointsBadExample = `
+
+`
+const GkeLegacyMetadataEndpointsGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: GkeLegacyMetadataEndpoints,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GkeLegacyMetadataEndpointsDescription,
+            Explanation: GkeLegacyMetadataEndpointsExplanation,
+            BadExample:  GkeLegacyMetadataEndpointsBadExample,
+            GoodExample: GkeLegacyMetadataEndpointsGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/gke_node_metadata_exposed.go
+++ b/internal/app/tfsec/checks/gke_node_metadata_exposed.go
@@ -13,12 +13,25 @@ import (
 // GkeNodeMetadataExposed See https://github.com/tfsec/tfsec#included-checks for check info
 const GkeNodeMetadataExposed scanner.RuleID = "GCP006"
 const GkeNodeMetadataExposedDescription scanner.RuleSummary = "Node metadata value disables metadata concealment."
+const GkeNodeMetadataExposedExplanation = `
+
+`
+const GkeNodeMetadataExposedBadExample = `
+
+`
+const GkeNodeMetadataExposedGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: GkeNodeMetadataExposed,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GkeNodeMetadataExposedDescription,
+            Explanation: GkeNodeMetadataExposedExplanation,
+            BadExample:  GkeNodeMetadataExposedBadExample,
+            GoodExample: GkeNodeMetadataExposedGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/gke_shielded_nodes_disabled.go
+++ b/internal/app/tfsec/checks/gke_shielded_nodes_disabled.go
@@ -13,12 +13,25 @@ import (
 // GkeShieldedNodesDisabled See https://github.com/tfsec/tfsec#included-checks for check info
 const GkeShieldedNodesDisabled scanner.RuleID = "GCP010"
 const GkeShieldedNodesDisabledDescription scanner.RuleSummary = "Shielded GKE nodes not enabled."
+const GkeShieldedNodesDisabledExplanation = `
+
+`
+const GkeShieldedNodesDisabledBadExample = `
+
+`
+const GkeShieldedNodesDisabledGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: GkeShieldedNodesDisabled,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GkeShieldedNodesDisabledDescription,
+            Explanation: GkeShieldedNodesDisabledExplanation,
+            BadExample:  GkeShieldedNodesDisabledBadExample,
+            GoodExample: GkeShieldedNodesDisabledGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/google_open_firewall_rules.go
+++ b/internal/app/tfsec/checks/google_open_firewall_rules.go
@@ -12,6 +12,15 @@ import (
 // GoogleOpenInboundFirewallRule See https://github.com/tfsec/tfsec#included-checks for check info
 const GoogleOpenInboundFirewallRule scanner.RuleID = "GCP003"
 const GoogleOpenInboundFirewallRuleDescription scanner.RuleSummary = "An inbound firewall rule allows traffic from `/0`."
+const GoogleOpenInboundFirewallRuleExplanation = `
+
+`
+const GoogleOpenInboundFirewallRuleBadExample = `
+
+`
+const GoogleOpenInboundFirewallRuleGoodExample = `
+
+`
 
 // GoogleOpenOutboundFirewallRule See https://github.com/tfsec/tfsec#included-checks for check info
 const GoogleOpenOutboundFirewallRule scanner.RuleID = "GCP004"
@@ -22,6 +31,10 @@ func init() {
 		Code: GoogleOpenInboundFirewallRule,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GoogleOpenInboundFirewallRuleDescription,
+            Explanation: GoogleOpenInboundFirewallRuleExplanation,
+            BadExample:  GoogleOpenInboundFirewallRuleBadExample,
+            GoodExample: GoogleOpenInboundFirewallRuleGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/google_unencrypted_disk.go
+++ b/internal/app/tfsec/checks/google_unencrypted_disk.go
@@ -10,12 +10,25 @@ import (
 // GoogleUnencryptedDisk See https://github.com/tfsec/tfsec#included-checks for check info
 const GoogleUnencryptedDisk scanner.RuleID = "GCP001"
 const GoogleUnencryptedDiskDescription scanner.RuleSummary = "Unencrypted compute disk."
+const GoogleUnencryptedDiskExplanation = `
+
+`
+const GoogleUnencryptedDiskBadExample = `
+
+`
+const GoogleUnencryptedDiskGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: GoogleUnencryptedDisk,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GoogleUnencryptedDiskDescription,
+            Explanation: GoogleUnencryptedDiskExplanation,
+            BadExample:  GoogleUnencryptedDiskBadExample,
+            GoodExample: GoogleUnencryptedDiskGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/google_unencrypted_storage_bucket.go
+++ b/internal/app/tfsec/checks/google_unencrypted_storage_bucket.go
@@ -10,12 +10,25 @@ import (
 // GoogleUnencryptedStorageBucket See https://github.com/tfsec/tfsec#included-checks for check info
 const GoogleUnencryptedStorageBucket scanner.RuleID = "GCP002"
 const GoogleUnencryptedStorageBucketDescription scanner.RuleSummary = "Unencrypted storage bucket."
+const GoogleUnencryptedStorageBucketExplanation = `
+
+`
+const GoogleUnencryptedStorageBucketBadExample = `
+
+`
+const GoogleUnencryptedStorageBucketGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: GoogleUnencryptedStorageBucket,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GoogleUnencryptedStorageBucketDescription,
+            Explanation: GoogleUnencryptedStorageBucketExplanation,
+            BadExample:  GoogleUnencryptedStorageBucketBadExample,
+            GoodExample: GoogleUnencryptedStorageBucketGoodExample,
+            Links: []string{},
 		},
 		Provider:       scanner.GCPProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/checks/google_user_iam_grant.go
+++ b/internal/app/tfsec/checks/google_user_iam_grant.go
@@ -12,12 +12,25 @@ import (
 // GoogleUserIAMGrant See https://github.com/tfsec/tfsec#included-checks for check info
 const GoogleUserIAMGrant scanner.RuleID = "GCP011"
 const GoogleUserIAMGrantDescription scanner.RuleSummary = "IAM granted directly to user."
+const GoogleUserIAMGrantExplanation = `
+
+`
+const GoogleUserIAMGrantBadExample = `
+
+`
+const GoogleUserIAMGrantGoodExample = `
+
+`
 
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: GoogleUserIAMGrant,
 		Documentation: scanner.CheckDocumentation{
 			Summary: GoogleUserIAMGrantDescription,
+            Explanation: GoogleUserIAMGrantExplanation,
+            BadExample:  GoogleUserIAMGrantBadExample,
+            GoodExample: GoogleUserIAMGrantGoodExample,
+            Links: []string{},
 		},
 		Provider:      scanner.GCPProvider,
 		RequiredTypes: []string{"resource", "data"},

--- a/internal/app/tfsec/debug/debug.go
+++ b/internal/app/tfsec/debug/debug.go
@@ -1,0 +1,16 @@
+package debug
+
+import (
+	"fmt"
+	"time"
+)
+
+var Enabled bool
+
+func Log(format string, args ...interface{}) {
+	if !Enabled {
+		return
+	}
+	line := fmt.Sprintf(format, args...)
+	fmt.Printf("[DEBUG][%s] %s\n", time.Now(), line)
+}

--- a/internal/app/tfsec/scanner/scanner.go
+++ b/internal/app/tfsec/scanner/scanner.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/tfsec/tfsec/internal/app/tfsec/debug"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 )
 
@@ -35,6 +37,7 @@ func (scanner *Scanner) Scan(blocks []*parser.Block, excludedChecksList []string
 	for _, block := range blocks {
 		for _, check := range GetRegisteredChecks() {
 			if check.IsRequiredForBlock(block) {
+				debug.Log("Running check for %s on %s.%s (%s)...", check.Code, block.Type(), block.Name(), block.Range().Filename)
 				for _, result := range check.Run(block, context) {
 					if !scanner.checkRangeIgnored(result.RuleID, result.Range) && !checkInList(result.RuleID, excludedChecksList) {
 						results = append(results, result)


### PR DESCRIPTION
Should have done this manually...
```bash
#!/bin/bash

set -exo pipefail

fix_check () {
	file="$1"
	target=/tmp/target
	cp $file $target
	line=$(grep -n RuleSummary "$file" | head -n1 | awk -F':' '{print $1}')
	prefix=$(cat "$file" | grep 'const' | grep RuleSummary | head -n1 | awk '{print $2}' | sed 's/Summary//g' | sed 's/Description//g')
	cat > /tmp/addition <<- EOF
const ${prefix}Explanation = \`

\`
const ${prefix}BadExample = \`

\`
const ${prefix}GoodExample = \`

\`
EOF

	sed -e "${line}r /tmp/addition" "$target" > /tmp/intermediate

	docline=$(grep -n "Summary:" /tmp/intermediate | head -n1 | awk -F':' '{print $1}')
	cat > /tmp/docs <<- EOF
            Explanation: ${prefix}Explanation,
            BadExample:  ${prefix}BadExample,
            GoodExample: ${prefix}GoodExample,
            Links: []string{},
EOF

	sed -e "${docline}r /tmp/docs" /tmp/intermediate > $file
}

for f in `ls ./internal/app/tfsec/checks/`; do
	echo "Modifying $f..."
	fix_check "./internal/app/tfsec/checks/$f"
done

```