### PR TITLE
Add AWS SQS policy wildcard action check

### DIFF
--- a/internal/app/tfsec/checks/aws047.go
+++ b/internal/app/tfsec/checks/aws047.go
@@ -1,0 +1,96 @@
+package checks
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
+	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
+)
+
+const AWSSqsPolicyWildcardActions scanner.RuleCode = "AWS047"
+const AWSSqsPolicyWildcardActionsDescription scanner.RuleSummary = "AWS SQS policy document has wildcard action statement."
+const AWSSqsPolicyWildcardActionsExplanation = `
+SQS Policy actions should always be restricted to a specific set.
+
+This ensures that the queue itself cannot be modified or deleted, and prevents possible future additions to queue actions to be implicitly allowed.
+`
+const AWSSqsPolicyWildcardActionsBadExample = `
+resource "aws_sqs_queue_policy" "test" {
+  queue_url = aws_sqs_queue.q.id
+
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "*"
+    }
+  ]
+}
+POLICY
+}
+`
+const AWSSqsPolicyWildcardActionsGoodExample = `
+resource "aws_sqs_queue_policy" "test" {
+  queue_url = aws_sqs_queue.q.id
+
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage"
+    }
+  ]
+}
+POLICY
+}
+`
+
+func init() {
+	scanner.RegisterCheck(scanner.Check{
+		Code: AWSSqsPolicyWildcardActions,
+		Documentation: scanner.CheckDocumentation{
+			Summary:     AWSSqsPolicyWildcardActionsDescription,
+			Explanation: AWSSqsPolicyWildcardActionsExplanation,
+			BadExample:  AWSSqsPolicyWildcardActionsBadExample,
+			GoodExample: AWSSqsPolicyWildcardActionsGoodExample,
+			Links:       []string{
+				"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-security-best-practices.html",
+				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy",
+			},
+		},
+		Provider:       scanner.AWSProvider,
+		RequiredTypes:  []string{"resource"},
+		RequiredLabels: []string{"aws_sqs_queue_policy"},
+		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
+			rawJSON := []byte(block.GetAttribute("policy").Value().AsString())
+			var policy struct {
+				Statement []struct {
+					Effect string `json:"Effect"`
+					Action string `json:"Action"`
+				} `json:"Statement"`
+			}
+
+			if err := json.Unmarshal(rawJSON, &policy); err == nil {
+				for _, statement := range policy.Statement {
+					if strings.ToLower(statement.Effect) == "allow" && (statement.Action == "*" || statement.Action == "sqs:*") {
+						return []scanner.Result{
+							check.NewResult(
+								fmt.Sprintf("SQS policy '%s' has a wildcard action specified.", block.Name()),
+								block.Range(),
+								scanner.SeverityError,
+							),
+						}
+					}
+				}
+			}
+
+			return nil
+		},
+	})
+}

--- a/internal/app/tfsec/test/aws047_test.go
+++ b/internal/app/tfsec/test/aws047_test.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/tfsec/tfsec/internal/app/tfsec/checks"
+	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
+)
+
+func Test_AWSSqsPolicyWildcardActions(t *testing.T) {
+
+	var tests = []struct {
+		name                  string
+		source                string
+		mustIncludeResultCode scanner.RuleCode
+		mustExcludeResultCode scanner.RuleCode
+	}{
+		{
+			name:                  "check with bad example",
+			source:                checks.AWSSqsPolicyWildcardActionsBadExample,
+			mustIncludeResultCode: checks.AWSSqsPolicyWildcardActions,
+		},
+		{
+			name:                  "check with good example",
+			source:                checks.AWSSqsPolicyWildcardActionsGoodExample,
+			mustExcludeResultCode: checks.AWSSqsPolicyWildcardActions,
+		},
+		{
+			name: "check with actions defined as an array",
+			source: `
+resource "aws_sqs_queue_policy" "test" {
+  queue_url = aws_sqs_queue.q.id
+
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["sqs:SendMessage", "sqs:ReceiveMessage"],
+    }
+  ]
+}
+POLICY
+}
+`,
+			mustExcludeResultCode: checks.AWSSqsPolicyWildcardActions,
+		},
+		{
+			name: "check with prefixed wildcard action",
+			source: `
+resource "aws_sqs_queue_policy" "test" {
+  queue_url = aws_sqs_queue.q.id
+
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sqs:*"
+    }
+  ]
+}
+POLICY
+}
+`,
+			mustIncludeResultCode: checks.AWSSqsPolicyWildcardActions,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := scanSource(test.source)
+			assertCheckCode(t, test.mustIncludeResultCode, test.mustExcludeResultCode, results)
+		})
+	}
+
+}


### PR DESCRIPTION
A new check for AWS to check for wildcard actions defined in
`aws_sqs_queue_policy` resources.

Fixes #274