### PR TITLE
Add documentation for AWS018

### DIFF
--- a/internal/app/tfsec/checks/aws018.go
+++ b/internal/app/tfsec/checks/aws018.go
@@ -13,13 +13,13 @@ import (
 // AWSNoDescriptionInSecurityGroup See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSNoDescriptionInSecurityGroup scanner.RuleCode = "AWS018"
 const AWSNoDescriptionInSecurityGroupDescription scanner.RuleSummary = "Missing description for security group/security group rule."
-const AWSNoInSecurityGroupExplanation = `
+const AWSNoDescriptionInSecurityGroupExplanation = `
 
 `
-const AWSNoInSecurityGroupBadExample = `
+const AWSNoDescriptionInSecurityGroupBadExample = `
 
 `
-const AWSNoInSecurityGroupGoodExample = `
+const AWSNoDescriptionInSecurityGroupGoodExample = `
 
 `
 
@@ -28,9 +28,9 @@ func init() {
 		Code: AWSNoDescriptionInSecurityGroup,
 		Documentation: scanner.CheckDocumentation{
 			Summary:     AWSNoDescriptionInSecurityGroupDescription,
-			Explanation: AWSNoInSecurityGroupExplanation,
-			BadExample:  AWSNoInSecurityGroupBadExample,
-			GoodExample: AWSNoInSecurityGroupGoodExample,
+			Explanation: AWSNoDescriptionInSecurityGroupExplanation,
+			BadExample:  AWSNoDescriptionInSecurityGroupBadExample,
+			GoodExample: AWSNoDescriptionInSecurityGroupGoodExample,
 			Links:       []string{},
 		},
 		Provider:       scanner.AWSProvider,

--- a/internal/app/tfsec/checks/aws018.go
+++ b/internal/app/tfsec/checks/aws018.go
@@ -14,13 +14,36 @@ import (
 const AWSNoDescriptionInSecurityGroup scanner.RuleCode = "AWS018"
 const AWSNoDescriptionInSecurityGroupDescription scanner.RuleSummary = "Missing description for security group/security group rule."
 const AWSNoDescriptionInSecurityGroupExplanation = `
+Security groups and security group rules should include a description for auditing purposes.
 
+Simplifies auditing, debugging, and managing security groups.
 `
 const AWSNoDescriptionInSecurityGroupBadExample = `
+resource "aws_security_group" "http" {
+  name        = "http"
 
+  ingress {
+    description = "HTTP from VPC"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [aws_vpc.main.cidr_block]
+  }
+}
 `
 const AWSNoDescriptionInSecurityGroupGoodExample = `
+resource "aws_security_group" "http" {
+  name        = "http"
+  description = "Allow inbound HTTP traffic"
 
+  ingress {
+    description = "HTTP from VPC"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [aws_vpc.main.cidr_block]
+  }
+}
 `
 
 func init() {
@@ -31,7 +54,11 @@ func init() {
 			Explanation: AWSNoDescriptionInSecurityGroupExplanation,
 			BadExample:  AWSNoDescriptionInSecurityGroupBadExample,
 			GoodExample: AWSNoDescriptionInSecurityGroupGoodExample,
-			Links:       []string{},
+			Links: []string{
+				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group",
+				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule",
+				"https://www.cloudconformity.com/knowledge-base/aws/EC2/security-group-rules-description.html",
+			},
 		},
 		Provider:       scanner.AWSProvider,
 		RequiredTypes:  []string{"resource"},

--- a/internal/app/tfsec/test/aws018_test.go
+++ b/internal/app/tfsec/test/aws018_test.go
@@ -47,6 +47,16 @@ resource "aws_security_group_rule" "my-rule" {
 }`,
 			mustExcludeResultCode: checks.AWSNoDescriptionInSecurityGroup,
 		},
+		{
+			name:                  "check aws_security_group good example",
+			source:                checks.AWSNoDescriptionInSecurityGroupGoodExample,
+			mustExcludeResultCode: checks.AWSNoDescriptionInSecurityGroup,
+		},
+		{
+			name:                  "check aws_security_group bad example",
+			source:                checks.AWSNoDescriptionInSecurityGroupBadExample,
+			mustIncludeResultCode: checks.AWSNoDescriptionInSecurityGroup,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Added explanation, examples and reference links to _AWS018_ `AWSNoDescriptionInSecurityGroup` check. Added the  examples to the test as well.

Renamed the 3 documentation constants to match the scanner constants above.

Relates to #269 (actual check is already implemented here)
