### PR TITLE
Fix AWS006 message for IPv6 CIDR

### DIFF
--- a/internal/app/tfsec/checks/aws006.go
+++ b/internal/app/tfsec/checks/aws006.go
@@ -85,7 +85,7 @@ func init() {
 					if strings.HasSuffix(cidr.AsString(), "/0") {
 						return []scanner.Result{
 							check.NewResultWithValueAnnotation(
-								fmt.Sprintf("Resource '%s' defines a fully open egress security group rule.", block.Name()),
+								fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", block.Name()),
 								ipv6CidrBlocksAttr.Range(),
 								ipv6CidrBlocksAttr,
 								scanner.SeverityWarning,


### PR DESCRIPTION
The message in `AWS006` (`AWSOpenIngressSecurityGroupRule`) in the IPv6
cidr section mentions an *egress* rule, though it actually checks for an
*ingress* rule.