### PR TITLE
Extract open cidr checks into util function

### DIFF
--- a/internal/app/tfsec/checks/aws006.go
+++ b/internal/app/tfsec/checks/aws006.go
@@ -2,8 +2,6 @@ package checks
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 
 	"github.com/zclconf/go-cty/cty"
@@ -57,24 +55,13 @@ func init() {
 
 			if cidrBlocksAttr := block.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
 
-				if cidrBlocksAttr.Value().IsNull() || cidrBlocksAttr.Value().LengthInt() == 0 {
-					return nil
-				}
-
-				for _, cidr := range cidrBlocksAttr.Value().AsValueSlice() {
-
-					if cidr.Type() != cty.String {
-						continue
-					}
-
-					if strings.HasSuffix(cidr.AsString(), "/0") {
-						return []scanner.Result{
-							check.NewResult(
-								fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", block.FullName()),
-								cidrBlocksAttr.Range(),
-								scanner.SeverityWarning,
-							),
-						}
+				if isOpenCidr(cidrBlocksAttr, check.Provider) {
+					return []scanner.Result{
+						check.NewResult(
+							fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", block.FullName()),
+							cidrBlocksAttr.Range(),
+							scanner.SeverityWarning,
+						),
 					}
 				}
 
@@ -82,25 +69,14 @@ func init() {
 
 			if ipv6CidrBlocksAttr := block.GetAttribute("ipv6_cidr_blocks"); ipv6CidrBlocksAttr != nil {
 
-				if ipv6CidrBlocksAttr.Value().IsNull() || ipv6CidrBlocksAttr.Value().LengthInt() == 0 {
-					return nil
-				}
-
-				for _, cidr := range ipv6CidrBlocksAttr.Value().AsValueSlice() {
-
-					if cidr.Type() != cty.String {
-						continue
-					}
-
-					if strings.HasSuffix(cidr.AsString(), "/0") {
-						return []scanner.Result{
-							check.NewResultWithValueAnnotation(
-								fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", block.FullName()),
-								ipv6CidrBlocksAttr.Range(),
-								ipv6CidrBlocksAttr,
-								scanner.SeverityWarning,
-							),
-						}
+				if isOpenCidr(ipv6CidrBlocksAttr, check.Provider) {
+					return []scanner.Result{
+						check.NewResultWithValueAnnotation(
+							fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", block.FullName()),
+							ipv6CidrBlocksAttr.Range(),
+							ipv6CidrBlocksAttr,
+							scanner.SeverityWarning,
+						),
 					}
 				}
 

--- a/internal/app/tfsec/checks/aws007.go
+++ b/internal/app/tfsec/checks/aws007.go
@@ -2,8 +2,6 @@ package checks
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
@@ -56,50 +54,30 @@ func init() {
 
 			if cidrBlocksAttr := block.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
 
-				if cidrBlocksAttr.Value().IsNull() || cidrBlocksAttr.Value().LengthInt() == 0 {
-					return nil
-				}
-
-				for _, cidr := range cidrBlocksAttr.Value().AsValueSlice() {
-					if cidr.Type() != cty.String {
-						continue
-					}
-					if strings.HasSuffix(cidr.AsString(), "/0") {
-						return []scanner.Result{
-							check.NewResultWithValueAnnotation(
-								fmt.Sprintf("Resource '%s' defines a fully open egress security group rule.", block.FullName()),
-								cidrBlocksAttr.Range(),
-								cidrBlocksAttr,
-								scanner.SeverityWarning,
-							),
-						}
+				if isOpenCidr(cidrBlocksAttr, check.Provider) {
+					return []scanner.Result{
+						check.NewResultWithValueAnnotation(
+							fmt.Sprintf("Resource '%s' defines a fully open egress security group rule.", block.FullName()),
+							cidrBlocksAttr.Range(),
+							cidrBlocksAttr,
+							scanner.SeverityWarning,
+						),
 					}
 				}
-
 			}
 
 			if ipv6CidrBlocksAttr := block.GetAttribute("ipv6_cidr_blocks"); ipv6CidrBlocksAttr != nil {
 
-				if ipv6CidrBlocksAttr.Value().IsNull() || ipv6CidrBlocksAttr.Value().LengthInt() == 0 {
-					return nil
-				}
-
-				for _, cidr := range ipv6CidrBlocksAttr.Value().AsValueSlice() {
-					if cidr.Type() != cty.String {
-						continue
-					}
-					if strings.HasSuffix(cidr.AsString(), "/0") {
-						return []scanner.Result{
-							check.NewResultWithValueAnnotation(
-								fmt.Sprintf("Resource '%s' defines a fully open egress security group rule.", block.FullName()),
-								ipv6CidrBlocksAttr.Range(),
-								ipv6CidrBlocksAttr,
-								scanner.SeverityWarning,
-							),
-						}
+				if isOpenCidr(ipv6CidrBlocksAttr, check.Provider) {
+					return []scanner.Result{
+						check.NewResultWithValueAnnotation(
+							fmt.Sprintf("Resource '%s' defines a fully open egress security group rule.", block.FullName()),
+							ipv6CidrBlocksAttr.Range(),
+							ipv6CidrBlocksAttr,
+							scanner.SeverityWarning,
+						),
 					}
 				}
-
 			}
 
 			return nil

--- a/internal/app/tfsec/checks/aws008.go
+++ b/internal/app/tfsec/checks/aws008.go
@@ -2,10 +2,6 @@ package checks
 
 import (
 	"fmt"
-	"strings"
-
-	"github.com/zclconf/go-cty/cty"
-
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
@@ -53,41 +49,27 @@ func init() {
 			for _, directionBlock := range block.GetBlocks("ingress") {
 				if cidrBlocksAttr := directionBlock.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
 
-					if cidrBlocksAttr.Value().IsNull() || cidrBlocksAttr.Value().LengthInt() == 0 {
-						return nil
-					}
-
-					for _, cidr := range cidrBlocksAttr.Value().AsValueSlice() {
-						if cidr.Type() != cty.String {
-							continue
-						}
-						if strings.HasSuffix(cidr.AsString(), "/0") {
-							results = append(results,
-								check.NewResult(
-									fmt.Sprintf("Resource '%s' defines a fully open ingress security group.", block.FullName()),
-									cidrBlocksAttr.Range(),
-									scanner.SeverityWarning,
-								),
-							)
-						}
+					if isOpenCidr(cidrBlocksAttr, check.Provider) {
+						results = append(results,
+							check.NewResult(
+								fmt.Sprintf("Resource '%s' defines a fully open ingress security group.", block.FullName()),
+								cidrBlocksAttr.Range(),
+								scanner.SeverityWarning,
+							),
+						)
 					}
 				}
+
 				if cidrBlocksAttr := directionBlock.GetAttribute("ipv6_cidr_blocks"); cidrBlocksAttr != nil {
 
-					if cidrBlocksAttr.Value().IsNull() || cidrBlocksAttr.Value().LengthInt() == 0 {
-						return nil
-					}
-
-					for _, cidr := range cidrBlocksAttr.Value().AsValueSlice() {
-						if strings.HasSuffix(cidr.AsString(), "/0") {
-							results = append(results,
-								check.NewResult(
-									fmt.Sprintf("Resource '%s' defines a fully open ingress security group.", block.FullName()),
-									cidrBlocksAttr.Range(),
-									scanner.SeverityWarning,
-								),
-							)
-						}
+					if isOpenCidr(cidrBlocksAttr, check.Provider) {
+						results = append(results,
+							check.NewResult(
+								fmt.Sprintf("Resource '%s' defines a fully open ingress security group.", block.FullName()),
+								cidrBlocksAttr.Range(),
+								scanner.SeverityWarning,
+							),
+						)
 					}
 				}
 			}

--- a/internal/app/tfsec/checks/aws009.go
+++ b/internal/app/tfsec/checks/aws009.go
@@ -2,8 +2,6 @@ package checks
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -50,40 +48,29 @@ func init() {
 			for _, directionBlock := range block.GetBlocks("egress") {
 				if cidrBlocksAttr := directionBlock.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
 
-					if cidrBlocksAttr.Value().IsNull() || cidrBlocksAttr.Value().LengthInt() == 0 {
-						return nil
-					}
-
-					for _, cidr := range cidrBlocksAttr.Value().AsValueSlice() {
-						if strings.HasSuffix(cidr.AsString(), "/0") {
-							results = append(results,
-								check.NewResultWithValueAnnotation(
-									fmt.Sprintf("Resource '%s' defines a fully open egress security group.", block.FullName()),
-									cidrBlocksAttr.Range(),
-									cidrBlocksAttr,
-									scanner.SeverityWarning,
-								),
-							)
-						}
+					if isOpenCidr(cidrBlocksAttr, check.Provider) {
+						results = append(results,
+							check.NewResultWithValueAnnotation(
+								fmt.Sprintf("Resource '%s' defines a fully open egress security group.", block.FullName()),
+								cidrBlocksAttr.Range(),
+								cidrBlocksAttr,
+								scanner.SeverityWarning,
+							),
+						)
 					}
 				}
+
 				if cidrBlocksAttr := directionBlock.GetAttribute("ipv6_cidr_blocks"); cidrBlocksAttr != nil {
 
-					if cidrBlocksAttr.Value().IsNull() || cidrBlocksAttr.Value().LengthInt() == 0 {
-						return nil
-					}
-
-					for _, cidr := range cidrBlocksAttr.Value().AsValueSlice() {
-						if strings.HasSuffix(cidr.AsString(), "/0") {
-							results = append(results,
-								check.NewResultWithValueAnnotation(
-									fmt.Sprintf("Resource '%s' defines a fully open egress security group.", block.FullName()),
-									cidrBlocksAttr.Range(),
-									cidrBlocksAttr,
-									scanner.SeverityWarning,
-								),
-							)
-						}
+					if isOpenCidr(cidrBlocksAttr, check.Provider) {
+						results = append(results,
+							check.NewResultWithValueAnnotation(
+								fmt.Sprintf("Resource '%s' defines a fully open egress security group.", block.FullName()),
+								cidrBlocksAttr.Range(),
+								cidrBlocksAttr,
+								scanner.SeverityWarning,
+							),
+						)
 					}
 				}
 			}

--- a/internal/app/tfsec/checks/gcp004.go
+++ b/internal/app/tfsec/checks/gcp004.go
@@ -2,8 +2,6 @@ package checks
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -45,22 +43,15 @@ func init() {
 
 			if destinationRanges := block.GetAttribute("destination_ranges"); destinationRanges != nil {
 
-				if destinationRanges.Value().LengthInt() == 0 {
-					return nil
-				}
-
-				for _, cidr := range destinationRanges.Value().AsValueSlice() {
-					if strings.HasSuffix(cidr.AsString(), "/0") {
-						return []scanner.Result{
-							check.NewResult(
-								fmt.Sprintf("Resource '%s' defines a fully open outbound firewall rule.", block.FullName()),
-								destinationRanges.Range(),
-								scanner.SeverityWarning,
-							),
-						}
+				if isOpenCidr(destinationRanges, check.Provider) {
+					return []scanner.Result{
+						check.NewResult(
+							fmt.Sprintf("Resource '%s' defines a fully open outbound firewall rule.", block.FullName()),
+							destinationRanges.Range(),
+							scanner.SeverityWarning,
+						),
 					}
 				}
-
 			}
 
 			return nil

--- a/internal/app/tfsec/checks/utils.go
+++ b/internal/app/tfsec/checks/utils.go
@@ -2,7 +2,9 @@ package checks
 
 import (
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
+	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 	"github.com/zclconf/go-cty/cty"
+	"strings"
 )
 
 // isBooleanOrStringTrue returns true if the attribute is a boolean and is
@@ -16,4 +18,31 @@ func isBooleanOrStringTrue(val *parser.Attribute) bool {
 	default:
 		return false
 	}
+}
+
+// isOpenCidr returns true if given attribute is an open CIDR block
+func isOpenCidr(attr *parser.Attribute, provider scanner.RuleProvider) bool {
+	if attr.Value().IsNull() {
+		return false
+	}
+
+	var cidrList []cty.Value
+	if attr.Type() == cty.String {
+		cidrList = []cty.Value{attr.Value()}
+	} else {
+		cidrList = attr.Value().AsValueSlice()
+	}
+
+	for _, cidr := range cidrList {
+		if cidr.Type() != cty.String {
+			continue
+		}
+
+		cidrStr := cidr.AsString()
+		if strings.HasSuffix(cidrStr, "/0") || cidrStr == "*" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/app/tfsec/checks/utils_test.go
+++ b/internal/app/tfsec/checks/utils_test.go
@@ -1,6 +1,7 @@
 package checks
 
 import (
+	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 	"testing"
 
 	hcl "github.com/hashicorp/hcl/v2"
@@ -50,6 +51,118 @@ func Test_isBooleanOrStringTrue(t *testing.T) {
 		)
 		if result := isBooleanOrStringTrue(attr); result != test.result {
 			t.Errorf("expected %v got %v\n", test.val, result)
+		}
+	}
+}
+
+func Test_isOpenCidr(t *testing.T) {
+	var tests = []struct {
+		val      *parser.Attribute
+		rawExpr  string
+		provider scanner.RuleProvider
+		result   bool
+	}{
+		{
+			rawExpr:  `["0.0.0.0/0"]`,
+			provider: scanner.AWSProvider,
+			result:   true,
+		},
+		{
+			rawExpr:  `["1.2.3.4/0"]`,
+			provider: scanner.AWSProvider,
+			result:   true,
+		},
+		{
+			rawExpr:  `["2620:0:2d0:200::7/0"]`,
+			provider: scanner.AWSProvider,
+			result:   true,
+		},
+		{
+			rawExpr:  `["::/0"]`,
+			provider: scanner.AWSProvider,
+			result:   true,
+		},
+		{
+			rawExpr:  `["1.2.3.5/32"]`,
+			provider: scanner.AWSProvider,
+			result:   false,
+		},
+		{
+			rawExpr:  `["10.0.0.0/16"]`,
+			provider: scanner.AWSProvider,
+			result:   false,
+		},
+		{
+			rawExpr:  `["2620:0:2d0:200::7/32"]`,
+			provider: scanner.AWSProvider,
+			result:   false,
+		},
+		{
+			rawExpr:  `["172.16.32.0/20", "172.16.16.0/20", "172.16.0.0/20"]`,
+			provider: scanner.AWSProvider,
+			result:   false,
+		},
+		{
+			rawExpr:  `["172.16.32.0/20", "172.16.16.0/20", "172.16.0.0/20", "0.0.0.0/0"]`,
+			provider: scanner.AWSProvider,
+			result:   true,
+		},
+		{
+			rawExpr:  `["*"]`,
+			provider: scanner.AWSProvider,
+			result:   true,
+		},
+
+		// Azure
+		{
+			rawExpr:  `["10.0.0.0/16"]`,
+			provider: scanner.AzureProvider,
+			result:   false,
+		},
+		{
+			rawExpr:  `["10.0.0.0/0"]`,
+			provider: scanner.AzureProvider,
+			result:   true,
+		},
+		{
+			rawExpr:  `["*"]`,
+			provider: scanner.AzureProvider,
+			result:   true,
+		},
+		{
+			rawExpr:  `"*"`,
+			provider: scanner.AzureProvider,
+			result:   true,
+		},
+
+		// GCP
+		{
+			rawExpr:  `["10.0.0.0/16"]`,
+			provider: scanner.GCPProvider,
+			result:   false,
+		},
+		{
+			rawExpr:  `["10.0.0.0/0"]`,
+			provider: scanner.GCPProvider,
+			result:   true,
+		},
+		{
+			rawExpr:  `["*"]`,
+			provider: scanner.GCPProvider,
+			result:   true,
+		},
+	}
+
+	for _, test := range tests {
+		expr, _ := hclsyntax.ParseExpression([]byte(test.rawExpr), "", hcl.Pos{0, 0, 0})
+		attr := parser.NewAttribute(
+			&hclsyntax.Attribute{
+				Expr: expr,
+			},
+			nil,
+		)
+		if result := isOpenCidr(attr, test.provider); result != test.result {
+			t.Errorf("expected %v got %v\n", test.result, result)
 		}
 	}
 }


### PR DESCRIPTION
Extracted the repeated open CIDR checks into a separate utility function.

I realize this was "_unasked for_" and "_not discussed yet_" according to the contributing guide, though I figured it's the only way to move forward with even more of these checks planned.

Consider this a proposal, and open for discussion.

I'm not sure what to do with the similar checks for *azure*, as in that case, there also seems to be `"*"` possible as an open CIDR.