### PR TITLE
fix: README link tfsec.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ there are also checks which are provider agnostic.
 
 | Checks |
 |:---|
-|[AWS Checks](docs/AWS_CHECKS.md)|
-|[Azure Checks](docs/AZURE_CHECKS.md)|
-|[GCP Checks](docs/GCP_CHECKS.md)|
-|[General Checks](docs/GENERAL_CHECKS.md)|
+|[AWS Checks](https://www.tfsec.dev/docs/aws/home/)|
+|[Azure Checks](https://www.tfsec.dev/docs/azure/home/)|
+|[GCP Checks](https://www.tfsec.dev/docs/google/home/)|
+|[General Checks](https://www.tfsec.dev/docs/general/home/)|
 
 ## Running in CI
 


### PR DESCRIPTION
README link is missing, so link to https://www.tfsec.dev

P.S. congrats new website! Thanks!