### PR TITLE
Fix github_token -> GITHUB_TOKEN

### DIFF
--- a/docs-website/_docs/github_security_alerts.md
+++ b/docs-website/_docs/github_security_alerts.md
@@ -39,7 +39,7 @@ jobs:
         uses: tfsec/tfsec-sarif-action@v0.0.3
         with:
           sarif_file: tfsec.sarif         
-          github_token: ${{ secrets.github_token }}
+          github_token: $${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v1
@@ -70,7 +70,7 @@ If you have code that is deeper in the github repo, you can use `working_directo
         with:
           working_directory: terraform/relevant
           sarif_file: tfsec.sarif         
-          github_token: ${{ secrets.github_token }}
+          github_token: $${{ secrets.GITHUB_TOKEN }}
 
 ```
 


### PR DESCRIPTION
Hi!

[As per the docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow) the default GITHUB_TOKEN variable is uppercase.

I also noticed in the [github_security_alerts](https://www.tfsec.dev/docs/github_security_alerts/) page the example is not being rendered correct: 

```
          github_token: $
```

If I recall correctly prepending a `$` in front of the expression should prevent it being evaluated when the docs are being generated.

Stephen
