### PR TITLE
Azure Storage Account HTTPS enabled rule created

### DIFF
--- a/internal/app/tfsec/checks/azu010.go
+++ b/internal/app/tfsec/checks/azu010.go
@@ -1,0 +1,63 @@
+package checks
+
+import (
+	"fmt"
+
+	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
+	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const AZUStorageAccountHTTPSenabled scanner.RuleCode = "AZU010"
+const AZUStorageAccountHTTPSenabledDescription scanner.RuleSummary = "Ensure HTTPS is enabled on Azure Storage Account"
+const AZUStorageAccountHTTPSenabledExplanation = `
+Requiring HTTPS in Storage Account helps to minimize the risk of eavesdropping.
+`
+const AZUStorageAccountHTTPSenabledBadExample = `
+resource "azurerm_storage_account" "my-storage-account" {
+	enable_https_traffic_only = false
+}
+`
+const AZUStorageAccountHTTPSenabledGoodExample = `
+resource "azurerm_storage_account" "my-storage-account" {
+	enable_https_traffic_only = true
+}
+`
+
+func init() {
+	scanner.RegisterCheck(scanner.Check{
+		Code: AZUStorageAccountHTTPSenabled,
+		Documentation: scanner.CheckDocumentation{
+			Summary:     AZUStorageAccountHTTPSenabledDescription,
+			Explanation: AZUStorageAccountHTTPSenabledExplanation,
+			BadExample:  AZUStorageAccountHTTPSenabledBadExample,
+			GoodExample: AZUStorageAccountHTTPSenabledGoodExample,
+			Links: []string{
+				"https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account",
+				"https://docs.microsoft.com/en-us/azure/storage/blobs/security-recommendations",
+			},
+		},
+		Provider:       scanner.AzureProvider,
+		RequiredTypes:  []string{"resource"},
+		RequiredLabels: []string{"azurerm_storage_account", "enable_https_traffic_only"},
+		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
+
+			enabledAttr := block.GetAttribute("enable_https_traffic_only")
+			if enabledAttr != nil && enabledAttr.Type() == cty.Bool && enabledAttr.Value().False() {
+				return []scanner.Result{
+					check.NewResultWithValueAnnotation(
+						fmt.Sprintf(
+							"Resource '%s' enable_https_traffic_only disabled.",
+							block.FullName(),
+						),
+						enabledAttr.Range(),
+						enabledAttr,
+						scanner.SeverityError,
+					),
+				}
+			}
+
+			return nil
+		},
+	})
+}

--- a/internal/app/tfsec/test/azu010_test.go
+++ b/internal/app/tfsec/test/azu010_test.go
@@ -1,0 +1,51 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/tfsec/tfsec/internal/app/tfsec/checks"
+	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
+)
+
+func Test_AZUStorageAccountHTTPSenabled(t *testing.T) {
+
+	var tests = []struct {
+		name                  string
+		source                string
+		mustIncludeResultCode scanner.RuleCode
+		mustExcludeResultCode scanner.RuleCode
+	}{
+		{
+			name: "check azurerm_storage_account with no enable_https_traffic_only define",
+			source: `
+resource "azurerm_storage_account" "my-storage-account" {
+
+}`,
+mustExcludeResultCode: checks.AZUStorageAccountHTTPSenabled,
+		},
+		{
+			name: "check azurerm_storage_account with enable_https_traffic_only disabled",
+			source: `
+resource "azurerm_storage_account" "my-storage-account" {
+	enable_https_traffic_only = false
+}`,
+			mustIncludeResultCode: checks.AZUStorageAccountHTTPSenabled,
+		},
+		{
+			name: "check azurerm_storage_account with enable_https_traffic_only enabled",
+			source: `
+resource "azurerm_storage_account" "my-storage-account" {
+	enable_https_traffic_only = true
+}`,
+			mustExcludeResultCode: checks.AZUStorageAccountHTTPSenabled,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := scanSource(test.source)
+			assertCheckCode(t, test.mustIncludeResultCode, test.mustExcludeResultCode, results)
+		})
+	}
+
+}


### PR DESCRIPTION
Created rule AZ010 to verify if the flag enable_https_traffic_only is enabled in the Terraform Resource azurerm_storage_account. If this flag is not set, it will be automatically be set to true, so I added a nil check on the attribute.

Documentation:
- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account
- https://docs.microsoft.com/en-us/azure/storage/blobs/security-recommendations
- https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview