### PR TITLE
Added capital case format output for CSV and JSON

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -157,8 +157,12 @@ func getFormatter() (formatters.Formatter, error) {
 		return formatters.FormatDefault, nil
 	case "json":
 		return formatters.FormatJSON, nil
+	case "JSON":
+		return formatters.FormatJSON, nil	
 	case "csv":
 		return formatters.FormatCSV, nil
+	case "CSV":
+		return formatters.FormatCSV, nil		
 	case "checkstyle":
 		return formatters.FormatCheckStyle, nil
 	case "junit":


### PR DESCRIPTION
For easier user experience and alignment with the README.md (stating that CSV and JSON are supported in capital case).