### PR TITLE
Set format output to support uppercase & lowercase 

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -157,8 +157,12 @@ func getFormatter() (formatters.Formatter, error) {
 		return formatters.FormatDefault, nil
 	case "json":
 		return formatters.FormatJSON, nil
+	case "JSON":
+		return formatters.FormatJSON, nil	
 	case "csv":
 		return formatters.FormatCSV, nil
+	case "CSV":
+		return formatters.FormatCSV, nil		
 	case "checkstyle":
 		return formatters.FormatCheckStyle, nil
 	case "junit":

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -152,17 +152,13 @@ var rootCmd = &cobra.Command{
 }
 
 func getFormatter() (formatters.Formatter, error) {
-	switch format {
+	switch strings.ToLower(format) {
 	case "", "default":
 		return formatters.FormatDefault, nil
 	case "json":
 		return formatters.FormatJSON, nil
-	case "JSON":
-		return formatters.FormatJSON, nil	
 	case "csv":
 		return formatters.FormatCSV, nil
-	case "CSV":
-		return formatters.FormatCSV, nil		
 	case "checkstyle":
 		return formatters.FormatCheckStyle, nil
 	case "junit":


### PR DESCRIPTION
Formatter output set to lowercase, supporting uppercase and lowercase output types (CSV, JSON, csv, json etc.)