### PR TITLE
Support related link output for custom checks

### DIFF
--- a/internal/app/tfsec/formatters/default.go
+++ b/internal/app/tfsec/formatters/default.go
@@ -45,7 +45,7 @@ func FormatDefault(_ io.Writer, results []scanner.Result, _ string) error {
 
 `, result.RuleID, severity, result.Description, result.Range.String())
 		highlightCode(result)
-		tml.Printf("  <blue>See %s for more information.</blue>\n\n", result.Link)
+		tml.Printf("  <blue> %s </blue>\n\n", result.Link)
 	}
 
 	// TODO show files processed

--- a/internal/app/tfsec/formatters/junit.go
+++ b/internal/app/tfsec/formatters/junit.go
@@ -55,7 +55,7 @@ func FormatJUnit(w io.Writer, results []scanner.Result, _ string) error {
 				Time:      "0",
 				Failure: &JUnitFailure{
 					Message: result.Description,
-					Contents: fmt.Sprintf("%s\n%s\nMore information: %s",
+					Contents: fmt.Sprintf("%s\n%s\n%s",
 						result.Range.String(),
 						highlightCodeJunit(result),
 						result.Link),

--- a/internal/app/tfsec/formatters/sarif.go
+++ b/internal/app/tfsec/formatters/sarif.go
@@ -1,7 +1,6 @@
 package formatters
 
 import (
-	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
@@ -21,7 +20,7 @@ func FormatSarif(w io.Writer, results []scanner.Result, baseDir string) error {
 	for _, result := range results {
 		rule := run.AddRule(string(result.RuleID)).
 			WithDescription(result.Description).
-			WithHelp(fmt.Sprintf("You can lean more about %s at https://tfsec.dev/docs/%s/%s", result.RuleID, strings.ToLower(string(result.RuleProvider)), result.RuleID))
+			WithHelp(result.Link)
 
 		relativePath, err := filepath.Rel(baseDir, result.Range.Filename)
 		if err != nil {

--- a/internal/app/tfsec/formatters/text.go
+++ b/internal/app/tfsec/formatters/text.go
@@ -36,7 +36,7 @@ func FormatText(_ io.Writer, results []scanner.Result, _ string) error {
 
 `, result.RuleID, severity, result.Description, result.Range.String())
 		outputCode(result)
-		fmt.Printf("  $s\n\n", result.Link)
+		fmt.Printf("  %s\n\n", result.Link)
 	}
 
 	return nil

--- a/internal/app/tfsec/formatters/text.go
+++ b/internal/app/tfsec/formatters/text.go
@@ -36,7 +36,7 @@ func FormatText(_ io.Writer, results []scanner.Result, _ string) error {
 
 `, result.RuleID, severity, result.Description, result.Range.String())
 		outputCode(result)
-		fmt.Printf("  See %s for more information.\n\n", result.Link)
+		fmt.Printf("  $s\n\n", result.Link)
 	}
 
 	return nil

--- a/internal/app/tfsec/scanner/check.go
+++ b/internal/app/tfsec/scanner/check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"strings"
 
 	internalDebug "github.com/tfsec/tfsec/internal/app/tfsec/debug"
 	"github.com/zclconf/go-cty/cty"
@@ -66,8 +67,16 @@ func (check *Check) Run(block *parser.Block, context *Context) []Result {
 		}
 	}()
 	results := check.CheckFunc(check, block, context)
-	for i := range results { // supplement results with links to documentation site
-		results[i].Link = fmt.Sprintf("https://tfsec.dev/docs/%s/%s/", check.Provider, check.Code)
+	if check.Provider == "custom" {
+		for i := range results { // populate custom check results with relatedLinks
+			if len(check.Documentation.Links) > 0 {
+				results[i].Link = fmt.Sprintf("See the following link(s) for more information:\n\n   %s", strings.Join(check.Documentation.Links, "\n   "))
+			}
+		}
+	} else {
+		for i := range results { // supplement results with links to documentation site
+			results[i].Link = fmt.Sprintf("See https://tfsec.dev/docs/%s/%s/ for more information.", check.Provider, check.Code)
+		}
 	}
 	return results
 }


### PR DESCRIPTION
👋 Here's a quick PR that updates check output to account for custom checks. This changes the output based on provider so custom checks point to relatedLinks instead of `https://tfsec.dev/docs/custom/CUS001`.

It would be worthwhile to make sure you're happy with how the output is handled for the various other formats (ie: json, csv, checkstyle, junit, sarif). Feel free to tweak this! I just thought I'd put a PR in for this quick fix so custom checks aren't sent to a 404 😄 