### PR TITLE
Update GCP006

### DIFF
--- a/internal/app/tfsec/test/gcp006_test.go
+++ b/internal/app/tfsec/test/gcp006_test.go
@@ -16,24 +16,100 @@ func Test_GkeNodeMetadataExposed(t *testing.T) {
 		mustExcludeResultCode scanner.RuleCode
 	}{
 		{
-			name: "check google_container_cluster with workload_metadata_config.node_metadata set to EXPOSE",
+			name: "check google_container_cluster with node_config.workload_metadata_config.node_metadata set to EXPOSE",
 			source: `
 resource "google_container_cluster" "gke" {
-	workload_metadata_config {
-		node_metadata = "EXPOSE"
+	node_config {
+		workload_metadata_config {
+			node_metadata = "EXPOSE"
 		}
+	}
 }`,
 			mustIncludeResultCode: checks.GkeNodeMetadataExposed,
 		},
 		{
-			name: "check google_container_cluster with workload_metadata_config.node_metadata set to UNSPECIFIED",
+			name: "check google_container_cluster with node_config.workload_metadata_config.node_metadata set to UNSPECIFIED",
 			source: `
 resource "google_container_cluster" "gke" {
-	workload_metadata_config {
-		node_metadata = "UNSPECIFIED"
+	node_config {
+		workload_metadata_config {
+			node_metadata = "UNSPECIFIED"
 		}
+	}
 }`,
 			mustIncludeResultCode: checks.GkeNodeMetadataExposed,
+		},
+		{
+			name: "check google_container_node_pool with node_config.workload_metadata_config.node_metadata set to EXPOSE",
+			source: `
+resource "google_container_node_pool" "gke" {
+	node_config {
+		workload_metadata_config {
+			node_metadata = "EXPOSE"
+		}
+	}
+}`,
+			mustIncludeResultCode: checks.GkeNodeMetadataExposed,
+		},
+		{
+			name: "check google_container_node_pool with node_config.workload_metadata_config.node_metadata set to UNSPECIFIED",
+			source: `
+resource "google_container_node_pool" "gke" {
+	node_config {
+		workload_metadata_config {
+			node_metadata = "UNSPECIFIED"
+		}
+	}
+}`,
+			mustIncludeResultCode: checks.GkeNodeMetadataExposed,
+		},
+		{
+			name: "check google_container_cluster with node_config.workload_metadata_config.node_metadata set to SECURE",
+			source: `
+resource "google_container_cluster" "gke" {
+	node_config {
+		workload_metadata_config {
+			node_metadata = "SECURE"
+		}
+	}
+}`,
+			mustExcludeResultCode: checks.GkeNodeMetadataExposed,
+		},
+		{
+			name: "check google_container_cluster with node_config.workload_metadata_config.node_metadata set to GKE_METADATA_SERVER",
+			source: `
+resource "google_container_cluster" "gke" {
+	node_config {
+		workload_metadata_config {
+			node_metadata = "GKE_METADATA_SERVER"
+		}
+	}
+}`,
+			mustExcludeResultCode: checks.GkeNodeMetadataExposed,
+		},
+		{
+			name: "check google_container_node_pool with node_config.workload_metadata_config.node_metadata set to SECURE",
+			source: `
+resource "google_container_node_pool" "gke" {
+	node_config {
+		workload_metadata_config {
+			node_metadata = "SECURE"
+		}
+	}
+}`,
+			mustExcludeResultCode: checks.GkeNodeMetadataExposed,
+		},
+		{
+			name: "check google_container_node_pool with node_config.workload_metadata_config.node_metadata set to GKE_METADATA_SERVER",
+			source: `
+resource "google_container_node_pool" "gke" {
+	node_config {
+		workload_metadata_config {
+			node_metadata = "GKE_METADATA_SERVER"
+		}
+	}
+}`,
+			mustExcludeResultCode: checks.GkeNodeMetadataExposed,
 		},
 	}
 


### PR DESCRIPTION
:wave: Made a small change to GCP006 to account for `google_container_node_pool` resources as well. Both are defined the same way as this value is always within the node_config block. 

Also updated the tests as the original one was a bit lacklustre. 