### PR TITLE
Add additional test to verify AWS053

### DIFF
--- a/internal/app/tfsec/test/aws053_test.go
+++ b/internal/app/tfsec/test/aws053_test.go
@@ -67,7 +67,8 @@ resource "aws_db_instance" "foo" {
 }
 `,
 			mustIncludeResultCode: checks.AWSRDSPerformanceInsughtsEncryptionNotEnabled,
-		}, {
+		},
+		{
 			name: "Performance insights on aws_db_instance disable",
 			source: `
 resource "aws_db_instance" "foo" {
@@ -96,6 +97,28 @@ resource "aws_db_instance" "foo" {
   performance_insights_kms_key_id = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
 }
 `,
+			mustExcludeResultCode: checks.AWSRDSPerformanceInsughtsEncryptionNotEnabled,
+		},
+		{
+			name: "Testing issue 506: error when performance insights enabled and kms included",
+			source: `
+variable "kms_key_arn" {
+	default = "something"
+}
+
+variable "performance_insights_enabled" {
+	type = bool
+	default = true
+}
+
+resource "aws_db_instance" "foo" {
+  name                 = "bar"
+  deletion_protection             = var.deletion_protection
+  performance_insights_enabled    = var.performance_insights_enabled
+  performance_insights_kms_key_id = var.kms_key_arn
+  skip_final_snapshot             = var.skip_final_snapshot
+  kms_key_id                      = var.kms_key_arn
+}`,
 			mustExcludeResultCode: checks.AWSRDSPerformanceInsughtsEncryptionNotEnabled,
 		},
 	}


### PR DESCRIPTION
Addresses https://github.com/tfsec/tfsec/issues/506

Fixes issues in the `IsEmpty` when the value is unresolvable for any reason. `IsEmpty` ensures that there are some literal components.

This is a bit of mitigation - the issue mentioned by @gluehbirnenkopf seems to be slightly different from @calvinrodo in that Calvin is concatenating up the KMS value using parts while @gluehbirnenkopf looks like it is a case of using a var that doesn't have a default value. This could be resolved using `--tfvars-file terraform.tfvars` and passing vars for testing purposes