### PR TITLE
AWS KMS key rotation not available for SIGN_VERIFY keys

### DIFF
--- a/internal/app/tfsec/checks/aws019.go
+++ b/internal/app/tfsec/checks/aws019.go
@@ -43,7 +43,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			keyUsageAttr := block.GetAttribute("key_usage")
 
-			if keyUsageAttr != nil && keyUsageAttr.Value().AsString() == "SIGN_VERIFY" {
+			if keyUsageAttr != nil && keyUsageAttr.Equals("SIGN_VERIFY") {
 				return nil
 			}
 

--- a/internal/app/tfsec/checks/aws019.go
+++ b/internal/app/tfsec/checks/aws019.go
@@ -41,12 +41,13 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_kms_key"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
-			keyRotationAttr := block.GetAttribute("enable_key_rotation")
 			keyUsageAttr := block.GetAttribute("key_usage")
 
-			if keyUsageAttr.Value().AsString() == "SIGN_VERIFY" {
+			if keyUsageAttr != nil && keyUsageAttr.Value().AsString() == "SIGN_VERIFY" {
 				return nil
 			}
+
+			keyRotationAttr := block.GetAttribute("enable_key_rotation")
 
 			if keyRotationAttr == nil {
 				return []scanner.Result{

--- a/internal/app/tfsec/checks/aws019.go
+++ b/internal/app/tfsec/checks/aws019.go
@@ -42,6 +42,11 @@ func init() {
 		RequiredLabels: []string{"aws_kms_key"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			keyRotationAttr := block.GetAttribute("enable_key_rotation")
+			keyUsageAttr := block.GetAttribute("key_usage")
+
+			if keyUsageAttr.Value().AsString() == "SIGN_VERIFY" {
+				return nil
+			}
 
 			if keyRotationAttr == nil {
 				return []scanner.Result{

--- a/internal/app/tfsec/test/aws019_test.go
+++ b/internal/app/tfsec/test/aws019_test.go
@@ -35,6 +35,14 @@ resource "aws_kms_key" "kms_key" {
 }`,
 			mustExcludeResultCode: checks.AWSNoKMSAutoRotate,
 		},
+		{
+			name: "check SIGN_VERIFY KMS Key with auto-rotation disabled",
+			source: `
+resource "aws_kms_key" "kms_key" {
+	key_usage = "SIGN_VERIFY"
+}`,
+			mustExcludeResultCode: checks.AWSNoKMSAutoRotate,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This should allow folks to avoid ignoring cases they can do nothing about.