### PR TITLE
Fix broken link to tfsec-example-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ to specify your desired format.
 ## Github Security Alerts
 If you want to integrate with Github Security alerts and include the output of your tfsec checks you can use the [tfsec-sarif-action](https://github.com/marketplace/actions/run-tfsec-with-sarif-upload) Github action to run the static analysis then upload the results to the security alerts tab.
 
-The alerts generated for [tfsec-example-project](https://gighub.com/tfsec/tfsec-github-project) look like this.
+The alerts generated for [tfsec-example-project](https://github.com/tfsec/tfsec-example-project) look like this.
 
 ![github security alerts](codescanning.png)
 


### PR DESCRIPTION
Link for tfsec-example-project points to gighub.com (not github) and a project that doesn't exist.

This MR fixes the broken link. :smile: