### PR TITLE
GEN003: Add support for github_actions_secret.secret_name by whitelisting

### DIFF
--- a/internal/app/tfsec/checks/gen003.go
+++ b/internal/app/tfsec/checks/gen003.go
@@ -48,6 +48,11 @@ var sensitiveWhitelist = []struct {
 		Resource:  "aws_instance",
 		Attribute: "get_password_data",
 	},
+	// GitHub provider
+	{
+		Resource:  "github_actions_secret",
+		Attribute: "secret_name",
+	},
 }
 
 func init() {

--- a/internal/app/tfsec/test/gen003_test.go
+++ b/internal/app/tfsec/test/gen003_test.go
@@ -47,5 +47,30 @@ resource "aws_efs_file_system" "myfs" {
 			assertCheckCode(t, test.mustIncludeResultCode, test.mustExcludeResultCode, results)
 		})
 	}
+}
 
+func Test_GitHubSensitiveAttributes(t *testing.T) {
+
+	var tests = []struct {
+		name                  string
+		source                string
+		mustIncludeResultCode scanner.RuleCode
+		mustExcludeResultCode scanner.RuleCode
+	}{
+		{
+			name: "avoid false positive for github_actions_secret",
+			source: `
+resource "github_actions_secret" "infrastructure_digitalocean_deploy_user" {
+	secret_name = "digitalocean_deploy_user"
+}`,
+			mustExcludeResultCode: checks.GenericSensitiveAttributes,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := scanSource(test.source)
+			assertCheckCode(t, test.mustIncludeResultCode, test.mustExcludeResultCode, results)
+		})
+	}
 }


### PR DESCRIPTION
In one of my projects, I use the [GitHub Provider](https://www.terraform.io/docs/providers/github/index.html) to manage GitHub repository secrets (that can be used inside GitHub Action Workflows), like:

```hcl
resource "github_actions_secret" "infrastructure_digitalocean_deploy_user" {
   repository      = "infrastructure"
   secret_name     = "digitalocean_deploy_user"
   plaintext_value = var.digitalocean_deploy_user
}
```

Running tfsec at the moment leads to

```
Problem 27

  [GEN003][WARNING] Block 'module.github:github_actions_secret.infrastructure_digitalocean_deploy_user' includes a potentially sensitive attribute which is defined within the project.
  /infrastructure/infrastructure/github/action_secret.tf:201

     198 | // User to be used to execute this deploy
     199 | resource "github_actions_secret" "infrastructure_digitalocean_deploy_user" {
     200 |   repository      = "infrastructure"
     201 |   secret_name     = "digitalocean_deploy_user"
     202 |   plaintext_value = var.digitalocean_deploy_user
     203 | }
     204 |

   See https://tfsec.dev/docs/general/GEN003/ for more information.
```

This PR whitelists the attribute `secret_name` of the [github_actions_secret](https://www.terraform.io/docs/providers/github/r/actions_secret.html) resource.

### Additional note

I am aware that the [GitHub Provider](https://www.terraform.io/docs/providers/github/index.html) is not part of this repository at all. Not sure how the roadmap of this project looks like (mainly if non-cloud resources are also accepted).

Just let me know if GitHub doesn't fit into the scope of this project.