### PR TITLE
Fix docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ COPY --from=build-env /src/tfsec /usr/bin/tfsec
 # set the default entrypoint -- when this container is run, use this command
 ENTRYPOINT [ "tfsec" ]
 
-# as we specified an entrytrypoint, this is appended as an argument (i.e., `tfsec --help`)
+# as we specified an entrypoint, this is appended as an argument (i.e., `tfsec --help`)
 CMD [ "--help" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ WORKDIR /src
 ENV CGO_ENABLED=0
 RUN go build \
   -a \
-  -ldflags "-X github.com/tfsec/tfsec/version.Version=${tfsec_version}" \
-  -ldflags "-s -w -extldflags '-static'" \
+  -ldflags "-X github.com/tfsec/tfsec/version.Version=${tfsec_version} -s -w -extldflags '-static'" \
   -mod=vendor \
   ./cmd/tfsec
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,14 +5,14 @@ TAG=${TRAVIS_TAG:-development}
 GO111MODULE=on
 export CGO_ENABLED=0
 export GOFLAGS=-mod=vendor
-args=(-ldflags '-s -w -extldflags "-fno-PIC -static"')
+args=(-ldflags "-X github.com/tfsec/tfsec/version.Version=${TAG} -s -w -extldflags '-fno-PIC -static'")
 
 mkdir -p bin/darwin
-GOOS=darwin GOARCH=amd64 go build -o bin/darwin/${BINARY}-darwin-amd64 "${args[@]}" -ldflags "-X github.com/tfsec/tfsec/version.Version=${TAG}" ./cmd/tfsec/
-GOOS=darwin GOARCH=amd64 go build -o bin/darwin/${CHECK_GEN_BINARY}-darwin-amd64 -ldflags "-X github.com/tfsec/tfsec/version.Version=${TAG}" ./cmd/tfsec-checkgen/
+GOOS=darwin GOARCH=amd64 go build -o bin/darwin/${BINARY}-darwin-amd64 "${args[@]}" ./cmd/tfsec/
+GOOS=darwin GOARCH=amd64 go build -o bin/darwin/${CHECK_GEN_BINARY}-darwin-amd64 "${args[@]}" ./cmd/tfsec-checkgen/
 mkdir -p bin/linux
-GOOS=linux GOARCH=amd64 go build -o bin/linux/${BINARY}-linux-amd64 "${args[@]}" -ldflags "-X github.com/tfsec/tfsec/version.Version=${TAG}" ./cmd/tfsec/
-GOOS=linux GOARCH=amd64 go build -o bin/linux/${CHECK_GEN_BINARY}-linux-amd64 "${args[@]}" -ldflags "-X github.com/tfsec/tfsec/version.Version=${TAG}" ./cmd/tfsec-checkgen/
+GOOS=linux GOARCH=amd64 go build -o bin/linux/${BINARY}-linux-amd64 "${args[@]}" ./cmd/tfsec/
+GOOS=linux GOARCH=amd64 go build -o bin/linux/${CHECK_GEN_BINARY}-linux-amd64 "${args[@]}" ./cmd/tfsec-checkgen/
 mkdir -p bin/windows
-GOOS=windows GOARCH=amd64 go build -o bin/windows/${BINARY}-windows-amd64.exe "${args[@]}" -ldflags "-X github.com/tfsec/tfsec/version.Version=${TRAVIS_TAG}" ./cmd/tfsec/
-GOOS=windows GOARCH=amd64 go build -o bin/windows/${CHECK_GEN_BINARY}-windows-amd64.exe "${args[@]}" -ldflags "-X github.com/tfsec/tfsec/version.Version=${TRAVIS_TAG}" ./cmd/tfsec-checkgen/
+GOOS=windows GOARCH=amd64 go build -o bin/windows/${BINARY}-windows-amd64.exe "${args[@]}" ./cmd/tfsec/
+GOOS=windows GOARCH=amd64 go build -o bin/windows/${CHECK_GEN_BINARY}-windows-amd64.exe "${args[@]}" ./cmd/tfsec-checkgen/


### PR DESCRIPTION
Fixes #538

It looks like the change in #520 stopped the version number being set in the docker image, as it introduced multiple `-ldflags` arguments to the `go build` command, of which there can only be one. If there are multiple `-ldflags` then the last one takes precedence. The docker builds specify the version first, followed by the static linking flags, which is why the docker images didn't have the version number set.

This also updates the build script to use a single `-ldflags` argument, which means the binaries will now be statically linked.