### PR TITLE
Add the description to the JUnit output.

### DIFF
--- a/internal/app/tfsec/formatters/junit.go
+++ b/internal/app/tfsec/formatters/junit.go
@@ -51,7 +51,7 @@ func FormatJUnit(w io.Writer, results []scanner.Result, _ string) error {
 		output.TestCases = append(output.TestCases,
 			JUnitTestCase{
 				Classname: result.Range.Filename,
-				Name:      fmt.Sprintf("[%s][%s]", result.RuleID, result.Severity),
+				Name:      fmt.Sprintf("[%s][%s] - %s", result.RuleID, result.Severity, result.Description),
 				Time:      "0",
 				Failure: &JUnitFailure{
 					Message: result.Description,


### PR DESCRIPTION
Our users are not as familiar with the RuleIDs
and the description tends to contain a good hint about
what to do next.