### PR TITLE
push a minor tag pointing to latest patch

### DIFF
--- a/scripts/publish-image.sh
+++ b/scripts/publish-image.sh
@@ -9,8 +9,15 @@ for IMAGE in ${IMAGES[@]}; do
     docker build --build-arg tfsec_version=${TRAVIS_TAG} -t ${IMAGE} .
 
     echo "publishing ${IMAGE}..."
+    # push the patch tag - eg; v0.36.15
     docker tag ${IMAGE} ${IMAGE}:${TRAVIS_TAG}
     docker push ${IMAGE}:${TRAVIS_TAG}
+
+    # push the minor tag - eg; v0.36
+    docker tag ${IMAGE} ${IMAGE}:
+    docker push ${IMAGE}:${TRAVIS_TAG%.*}
+
+    # push the latest tag
     docker tag ${IMAGE} ${IMAGE}:latest
     docker push ${IMAGE}:latest
 done;


### PR DESCRIPTION
Resolves #541 

When tagging a patch version like v0.36.15, also tag a minor version pointing to that patch, eg v0.36. This will allow people to pin to v0.36 and benefit from new checks etc without risking the pinning to latest