### PR TITLE
added pre-commit hook for tfsec

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: tfsec
+  name: TFSec
+  description: TFsec is a tool to statically analyze Terraform templates to spot potential security issues.
+  language: golang
+  entry: tfsec
+  types: [terraform]


### PR DESCRIPTION
Pre-commit (https://pre-commit.com/index.html#intro) is a tool to easily install and run git hooks. By putting this file in the repo, it allows
people to automatically install tfsec with go and run tfsec against every commit.

This requires no additional upkeep on the tfsec project. Pre-commit will simply call go get to install tfsec automatically for anyone.