### PR TITLE
Simplify removeDuplicatesAndUnwanted()

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -172,14 +172,8 @@ var rootCmd = &cobra.Command{
 }
 
 func removeDuplicatesAndUnwanted(results []scanner.Result) []scanner.Result {
-	reduction := map[scanner.Result]bool{}
-
-	for _, result := range results {
-		reduction[result] = true
-	}
-
 	var returnVal []scanner.Result
-	for r, _ := range reduction {
+	for _, r := range results {
 		if excludeDownloaded && strings.Contains(r.Range.Filename, "/.terraform") {
 			continue
 		}


### PR DESCRIPTION
Removed redundant assignment of `results` to a `map[scanner.Result]bool{}` without using the `bool` from the `map`