### PR TITLE
Revert "Simplify removeDuplicatesAndUnwanted()"

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -172,8 +172,14 @@ var rootCmd = &cobra.Command{
 }
 
 func removeDuplicatesAndUnwanted(results []scanner.Result) []scanner.Result {
+	reduction := map[scanner.Result]bool{}
+
+	for _, result := range results {
+		reduction[result] = true
+	}
+
 	var returnVal []scanner.Result
-	for _, r := range results {
+	for r, _ := range reduction {
 		if excludeDownloaded && strings.Contains(r.Range.Filename, "/.terraform") {
 			continue
 		}


### PR DESCRIPTION
Reverts tfsec/tfsec#564

This doesn't have the desired effect. The .terraform was intended to be included but does present a risk of duplicates. 