### PR TITLE
Fix issue when loading a bad default config file 

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -96,32 +96,14 @@ var rootCmd = &cobra.Command{
 		tfsecDir := fmt.Sprintf("%s/.tfsec", dir)
 
 		if len(configFile) > 0 {
-			debug.Log("loading config file...")
-			tfsecConfig, err = config.LoadConfig(configFile)
-			if err != nil {
-				fmt.Fprint(os.Stderr, fmt.Sprintf("Failed to load the config file. %s", err))
-				os.Exit(1)
-			}
-			debug.Log("loaded config file %s", configFile)
+			tfsecConfig = loadConfigFile(configFile)
 		} else {
 			jsonConfigFile := fmt.Sprintf("%s/%s", tfsecDir, "config.json")
 			yamlConfigFile := fmt.Sprintf("%s/%s", tfsecDir, "config.yml")
 			if _, err = os.Stat(jsonConfigFile); err == nil {
-				debug.Log("loading config file...")
-				tfsecConfig, err = config.LoadConfig(jsonConfigFile)
-				if err != nil {
-					fmt.Fprint(os.Stderr, fmt.Sprintf("Failed to load the config file. %s", err))
-					os.Exit(1)
-				}
-				debug.Log("loaded config file %s", jsonConfigFile)
+				tfsecConfig = loadConfigFile(jsonConfigFile)
 			} else if _, err = os.Stat(yamlConfigFile); err == nil {
-				debug.Log("loading config file...")
-				tfsecConfig, err = config.LoadConfig(yamlConfigFile)
-				if err != nil {
-					fmt.Fprint(os.Stderr, fmt.Sprintf("Failed to load the config file. %s", err))
-					os.Exit(1)
-				}
-				debug.Log("loaded config file %s", yamlConfigFile)
+				tfsecConfig = loadConfigFile(yamlConfigFile)
 			}
 		}
 
@@ -281,4 +263,15 @@ func getFormatter() (formatters.Formatter, error) {
 	default:
 		return nil, fmt.Errorf("invalid format specified: '%s'", format)
 	}
+}
+
+func loadConfigFile(configFilePath string) *config.Config {
+	debug.Log("loading config file %s", configFilePath)
+	config, err := config.LoadConfig(configFilePath)
+	if err != nil {
+		fmt.Fprint(os.Stderr, fmt.Sprintf("Failed to load the config file. %s", err))
+		os.Exit(1)
+	}
+	debug.Log("loaded config file")
+	return config
 }

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -104,6 +104,8 @@ var rootCmd = &cobra.Command{
 				tfsecConfig = loadConfigFile(jsonConfigFile)
 			} else if _, err = os.Stat(yamlConfigFile); err == nil {
 				tfsecConfig = loadConfigFile(yamlConfigFile)
+			} else {
+			       tfsecConfig = &config.Config{}
 			}
 		}
 

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -96,18 +96,31 @@ var rootCmd = &cobra.Command{
 		tfsecDir := fmt.Sprintf("%s/.tfsec", dir)
 
 		if len(configFile) > 0 {
-			debug.Log("loading in the config file")
+			debug.Log("loading config file...")
 			tfsecConfig, err = config.LoadConfig(configFile)
 			if err != nil {
 				fmt.Fprint(os.Stderr, fmt.Sprintf("Failed to load the config file. %s", err))
 				os.Exit(1)
 			}
+			debug.Log("loaded config file %s", configFile)
 		} else {
 			jsonConfigFile := fmt.Sprintf("%s/%s", tfsecDir, "config.json")
 			yamlConfigFile := fmt.Sprintf("%s/%s", tfsecDir, "config.yml")
-			if tfsecConfig, err = config.LoadConfig(jsonConfigFile); err == nil {
+			if _, err = os.Stat(jsonConfigFile); err == nil {
+				debug.Log("loading config file...")
+				tfsecConfig, err = config.LoadConfig(jsonConfigFile)
+				if err != nil {
+					fmt.Fprint(os.Stderr, fmt.Sprintf("Failed to load the config file. %s", err))
+					os.Exit(1)
+				}
 				debug.Log("loaded config file %s", jsonConfigFile)
-			} else if tfsecConfig, err = config.LoadConfig(yamlConfigFile); err == nil {
+			} else if _, err = os.Stat(yamlConfigFile); err == nil {
+				debug.Log("loading config file...")
+				tfsecConfig, err = config.LoadConfig(yamlConfigFile)
+				if err != nil {
+					fmt.Fprint(os.Stderr, fmt.Sprintf("Failed to load the config file. %s", err))
+					os.Exit(1)
+				}
 				debug.Log("loaded config file %s", yamlConfigFile)
 			}
 		}

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -105,7 +105,7 @@ var rootCmd = &cobra.Command{
 			} else if _, err = os.Stat(yamlConfigFile); err == nil {
 				tfsecConfig = loadConfigFile(yamlConfigFile)
 			} else {
-			       tfsecConfig = &config.Config{}
+				tfsecConfig = &config.Config{}
 			}
 		}
 

--- a/docs-website/docs/config/config.md
+++ b/docs-website/docs/config/config.md
@@ -6,4 +6,4 @@ has_toc: no
 nav_order: 10
 ---
 
-tfsec configuration and overrides.
+## tfsec Configuration and Overrides


### PR DESCRIPTION
If the default config file is badly formed tfsec will not fail, instead it will continue to dereference a nil tfsecConfig pointer and crash.

To avoid this, first check if the default config file exists, if not we'll continue on happily; otherwise load the config and fail if there are any errors.