### PR TITLE
Add support for the .yml extension in custom check files

### DIFF
--- a/internal/app/tfsec/custom/loader.go
+++ b/internal/app/tfsec/custom/loader.go
@@ -69,8 +69,7 @@ func loadCheckFile(checkFilePath string) (ChecksFile, error) {
 		if err != nil {
 			return checks, err
 		}
-	case ".yml":
-	case ".yaml":
+	case ".yml", ".yaml":
 		err = yaml.Unmarshal(checkFileContent, &checks)
 		if err != nil {
 			return checks, nil


### PR DESCRIPTION
## Intent
To fix a bug that prevents custom check files from using the `.yml` extension.

## Context
Golang's switch statements have an implicit auto-break per case. See: https://tour.golang.org/flowcontrol/10

## Problem
Both `.yml` and `.yaml` extensions are accepted extensions for `YAML` custom check files.  However, the current implementation does not support the `.yml` due to how `switch` statement cases behave in Golang. 

## Solution
To use the comma-separated list syntax to represent the multiple valid cases for the YAML code path.

(cc: @muplim)