### PR TITLE
Add support for "and" and "or" predicates

### DIFF
--- a/docs-website/docs/config/custom_checks.md
+++ b/docs-website/docs/config/custom_checks.md
@@ -98,6 +98,7 @@ The `MatchSpec` is the what will define the check itself - this is fairly basic 
 | value | In cases where a value is required, the value to look for |
 | ignoreUndefined | If the attribute is undefined, ignore and pass the check |
 |subMatch | A sub MatchSpec block for nested checking - think looking for `enabled` value in a `logging` block |
+|subMatches | An array of sub MatchSpec block for nested checking. All sub MatchSpecs must match. |
 
 #### Check Actions
 There are a number of `CheckActions` available which should allow you to quickly put together most checks.

--- a/internal/app/tfsec/custom/check_all_statements_test.go
+++ b/internal/app/tfsec/custom/check_all_statements_test.go
@@ -44,7 +44,7 @@ func init() {
 			"action": "isPresent",
 			"subMatch": {
 				"action": "and",
-				"childMatchSpec": [{
+				"predicateMatchSpec": [{
 					"name": "actions",
 					"action": "notContains",
 					"value": "s3:Foo",

--- a/internal/app/tfsec/custom/check_all_statements_test.go
+++ b/internal/app/tfsec/custom/check_all_statements_test.go
@@ -1,0 +1,166 @@
+package custom
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func init() {
+	givenCheck(`{
+  "checks": [
+    {
+      "code": "DP011",
+      "description": "Amazon S3 permissions granted to other AWS accounts in bucket policies should be restricted",
+      "requiredTypes": [
+        "data"
+      ],
+      "requiredLabels": [
+        "aws_iam_policy_document"
+      ],
+      "severity": "ERROR",
+      "matchSpec": {
+        "name": "statement",
+        "action": "isPresent",
+        "subMatch": {
+          "name": "actions",
+          "action": "notContains",
+          "value": "s3:DeleteBucketPolicy",
+          "ignoreUndefined": true
+        }
+      }
+    },
+    {
+      "code": "DP012",
+      "description": "Amazon S3 permissions granted to other AWS accounts in bucket policies should be restricted",
+      "requiredTypes": [
+        "data"
+      ],
+      "requiredLabels": [
+        "imaginary_resource"
+      ],
+      "severity": "ERROR",
+      "matchSpec": {
+        "name": "statement",
+        "action": "isPresent",
+        "subMatches": [
+          {
+            "name": "actions",
+            "action": "notContains",
+            "value": "s3:Foo",
+            "ignoreUndefined": true
+          },
+          {
+            "name": "actions",
+            "action": "notContains",
+            "value": "s3:Bar",
+            "ignoreUndefined": true
+          }
+        ]
+      }
+    }
+  ]
+}
+`)
+}
+
+func TestSingleStatementMatches(t *testing.T) {
+	scanResults := scanTerraform(t, `
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:DeleteBucketPolicy",
+      "s3:GetObjectTagging",
+    ]
+    resources = ["*"]
+  }
+}
+
+`)
+	assert.Len(t, scanResults, 1)
+}
+
+func TestMultipleStatementsSecondMatch(t *testing.T) {
+	scanResults := scanTerraform(t, `
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {}
+
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:DeleteBucketPolicy",
+      "s3:GetObjectTagging",
+    ]
+    resources = ["*"]
+  }
+}
+`)
+	assert.Len(t, scanResults, 1)
+}
+
+func TestMultipleStatementsFirstMatch(t *testing.T) {
+	scanResults := scanTerraform(t, `
+data "aws_iam_policy_document" "bucket_policy" {
+
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:DeleteBucketPolicy",
+      "s3:GetObjectTagging",
+    ]
+    resources = ["*"]
+  }
+
+  statement {}
+}
+`)
+	assert.Len(t, scanResults, 1)
+}
+
+func TestNoMatches(t *testing.T) {
+	scanResults := scanTerraform(t, `
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {}
+}
+`)
+	assert.Len(t, scanResults, 0)
+}
+func TestMultipleSubmatchesOntoMultipleStatemetns(t *testing.T) {
+	scanResults := scanTerraform(t, `
+data "imaginary_resource" "bucket_policy" {
+  statement {
+    actions = ["s3:Foo"]
+  }
+}
+`)
+	assert.Len(t, scanResults, 1)
+
+	scanResults = scanTerraform(t, `
+data "imaginary_resource" "bucket_policy" {
+  statement {
+    actions = ["s3:Bar"]
+  }
+}
+`)
+	assert.Len(t, scanResults, 1)
+
+	scanResults = scanTerraform(t, `
+data "imaginary_resource" "bucket_policy" {
+  statement {}
+
+  statement {
+    actions = ["s3:Bar"]
+  }
+}
+`)
+	assert.Len(t, scanResults, 1)
+}

--- a/internal/app/tfsec/custom/check_all_statements_test.go
+++ b/internal/app/tfsec/custom/check_all_statements_test.go
@@ -40,24 +40,26 @@ func init() {
       ],
       "severity": "ERROR",
       "matchSpec": {
-			"name": "statement",
-			"action": "isPresent",
-			"subMatch": {
-				"action": "and",
-				"predicateMatchSpec": [{
-					"name": "actions",
-					"action": "notContains",
-					"value": "s3:Foo",
-					"ignoreUndefined": true
-				},
-				{
-					"name": "actions",
-					"action": "notContains",
-					"value": "s3:Bar",
-					"ignoreUndefined": true
-				}]
-			}
-		}
+        "name": "statement",
+        "action": "isPresent",
+        "subMatch": {
+          "action": "and",
+          "predicateMatchSpec": [
+            {
+              "name": "actions",
+              "action": "notContains",
+              "value": "s3:Foo",
+              "ignoreUndefined": true
+            },
+            {
+              "name": "actions",
+              "action": "notContains",
+              "value": "s3:Bar",
+              "ignoreUndefined": true
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/internal/app/tfsec/custom/check_all_statements_test.go
+++ b/internal/app/tfsec/custom/check_all_statements_test.go
@@ -40,23 +40,24 @@ func init() {
       ],
       "severity": "ERROR",
       "matchSpec": {
-        "name": "statement",
-        "action": "isPresent",
-        "subMatches": [
-          {
-            "name": "actions",
-            "action": "notContains",
-            "value": "s3:Foo",
-            "ignoreUndefined": true
-          },
-          {
-            "name": "actions",
-            "action": "notContains",
-            "value": "s3:Bar",
-            "ignoreUndefined": true
-          }
-        ]
-      }
+			"name": "statement",
+			"action": "isPresent",
+			"subMatch": {
+				"action": "and",
+				"childMatchSpec": [{
+					"name": "actions",
+					"action": "notContains",
+					"value": "s3:Foo",
+					"ignoreUndefined": true
+				},
+				{
+					"name": "actions",
+					"action": "notContains",
+					"value": "s3:Bar",
+					"ignoreUndefined": true
+				}]
+			}
+		}
     }
   ]
 }

--- a/internal/app/tfsec/custom/custom_check.go
+++ b/internal/app/tfsec/custom/custom_check.go
@@ -80,20 +80,20 @@ const GreaterThanOrEqualTo CheckAction = "greaterThanOrEqualTo"
 // RequiresPresence checks that a second resource is present
 const RequiresPresence CheckAction = "requiresPresence"
 
-// And checks that at both of the given ChildMatchSpec's evaluates to True
+// And checks that at both of the given predicateMatchSpec's evaluates to True
 const And CheckAction = "and"
 
-// Or checks that at least one of the given ChildMatchSpec's evaluates to True
+// Or checks that at least one of the given predicateMatchSpec's evaluates to True
 const Or CheckAction = "or"
 
 // MatchSpec specifies the checks that should be performed
 type MatchSpec struct {
-	Name            string      `json:"name,omitempty" yaml:"name,omitempty"`
-	MatchValue      interface{} `json:"value,omitempty" yaml:"value,omitempty"`
-	Action          CheckAction `json:"action,omitempty" yaml:"action,omitempty"`
-	PredicateMatchSpec  []MatchSpec `json:"childMatchSpec,omitempty" yaml:"childMatchSpec,omitempty"`
-	SubMatch        *MatchSpec  `json:"subMatch,omitempty" yaml:"subMatch,omitempty"`
-	IgnoreUndefined bool        `json:"ignoreUndefined,omitempty" yaml:"ignoreUndefined,omitempty"`
+	Name               string      `json:"name,omitempty" yaml:"name,omitempty"`
+	MatchValue         interface{} `json:"value,omitempty" yaml:"value,omitempty"`
+	Action             CheckAction `json:"action,omitempty" yaml:"action,omitempty"`
+	PredicateMatchSpec []MatchSpec `json:"predicateMatchSpec,omitempty" yaml:"predicateMatchSpec,omitempty"`
+	SubMatch           *MatchSpec  `json:"subMatch,omitempty" yaml:"subMatch,omitempty"`
+	IgnoreUndefined    bool        `json:"ignoreUndefined,omitempty" yaml:"ignoreUndefined,omitempty"`
 }
 
 //Check specifies the check definition represented in json/yaml

--- a/internal/app/tfsec/custom/custom_check.go
+++ b/internal/app/tfsec/custom/custom_check.go
@@ -91,7 +91,7 @@ type MatchSpec struct {
 	Name            string      `json:"name,omitempty" yaml:"name,omitempty"`
 	MatchValue      interface{} `json:"value,omitempty" yaml:"value,omitempty"`
 	Action          CheckAction `json:"action,omitempty" yaml:"action,omitempty"`
-	ChildMatchSpec  []MatchSpec `json:"childMatchSpec,omitempty" yaml:"childMatchSpec,omitempty"`
+	PredicateMatchSpec  []MatchSpec `json:"childMatchSpec,omitempty" yaml:"childMatchSpec,omitempty"`
 	SubMatch        *MatchSpec  `json:"subMatch,omitempty" yaml:"subMatch,omitempty"`
 	IgnoreUndefined bool        `json:"ignoreUndefined,omitempty" yaml:"ignoreUndefined,omitempty"`
 }

--- a/internal/app/tfsec/custom/custom_check.go
+++ b/internal/app/tfsec/custom/custom_check.go
@@ -25,6 +25,8 @@ var ValidCheckActions = []CheckAction{
 	RequiresPresence,
 	IsAny,
 	IsNone,
+	And,
+	Or,
 }
 
 // InModule checks that the block is part of a module
@@ -78,13 +80,19 @@ const GreaterThanOrEqualTo CheckAction = "greaterThanOrEqualTo"
 // RequiresPresence checks that a second resource is present
 const RequiresPresence CheckAction = "requiresPresence"
 
+// And checks that at both of the given ChildMatchSpec's evaluates to True
+const And CheckAction = "and"
+
+// Or checks that at least one of the given ChildMatchSpec's evaluates to True
+const Or CheckAction = "or"
+
 // MatchSpec specifies the checks that should be performed
 type MatchSpec struct {
 	Name            string      `json:"name,omitempty" yaml:"name,omitempty"`
 	MatchValue      interface{} `json:"value,omitempty" yaml:"value,omitempty"`
 	Action          CheckAction `json:"action,omitempty" yaml:"action,omitempty"`
+	ChildMatchSpec  []MatchSpec `json:"childMatchSpec,omitempty" yaml:"childMatchSpec,omitempty"`
 	SubMatch        *MatchSpec  `json:"subMatch,omitempty" yaml:"subMatch,omitempty"`
-	SubMatches      []MatchSpec `json:"subMatches,omitempty" yaml:"subMatches,omitempty"`
 	IgnoreUndefined bool        `json:"ignoreUndefined,omitempty" yaml:"ignoreUndefined,omitempty"`
 }
 

--- a/internal/app/tfsec/custom/custom_check.go
+++ b/internal/app/tfsec/custom/custom_check.go
@@ -84,6 +84,7 @@ type MatchSpec struct {
 	MatchValue      interface{} `json:"value,omitempty" yaml:"value,omitempty"`
 	Action          CheckAction `json:"action,omitempty" yaml:"action,omitempty"`
 	SubMatch        *MatchSpec  `json:"subMatch,omitempty" yaml:"subMatch,omitempty"`
+	SubMatches      []MatchSpec `json:"subMatches,omitempty" yaml:"subMatches,omitempty"`
 	IgnoreUndefined bool        `json:"ignoreUndefined,omitempty" yaml:"ignoreUndefined,omitempty"`
 }
 

--- a/internal/app/tfsec/custom/loader.go
+++ b/internal/app/tfsec/custom/loader.go
@@ -69,8 +69,7 @@ func loadCheckFile(checkFilePath string) (ChecksFile, error) {
 		if err != nil {
 			return checks, err
 		}
-	case ".yml":
-	case ".yaml":
+	case ".yml", ".yaml":
 		err = yaml.Unmarshal(checkFileContent, &checks)
 		if err != nil {
 			return checks, nil

--- a/internal/app/tfsec/custom/multiple_submatches_test.go
+++ b/internal/app/tfsec/custom/multiple_submatches_test.go
@@ -1,0 +1,80 @@
+package custom
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func init() {
+	givenCheck(`{
+  "checks": [
+    {
+      "code": "CUSTOM",
+      "description": "Instance Metadata Service V2 is required",
+      "requiredTypes": [
+        "resource"
+      ],
+      "requiredLabels": [
+        "aws_instance"
+      ],
+      "severity": "ERROR",
+      "matchSpec": {
+        "name": "metadata_options",
+        "action": "isPresent",
+        "subMatches": [
+          {
+            "name": "http_endpoint",
+            "action": "equals",
+            "value": "enabled"
+          },
+          {
+            "name": "http_put_response_hop_limit",
+            "action": "equals",
+            "value": 1
+          },
+          {
+            "name": "http_tokens",
+            "action": "equals",
+            "value": "required"
+          }
+        ]
+      }
+    }
+  ]
+}
+    `)
+}
+
+func TestInstanceMetadataEndpointPresent(t *testing.T) {
+	scanResults := scanTerraform(t, `
+resource "aws_instance" "bastion" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_put_response_hop_limit = 1
+    http_tokens                 = "required"
+  }
+}
+`)
+	assert.Len(t, scanResults, 0)
+}
+
+func TestInstanceMetadataEndpointMissing(t *testing.T) {
+	scanResults := scanTerraform(t, `
+resource "aws_instance" "bastion" {
+}
+`)
+	assert.Len(t, scanResults, 1)
+}
+
+func TestOneSubmatchHasWrongValue(t *testing.T) {
+	scanResults := scanTerraform(t, `
+resource "aws_instance" "bastion" {
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_put_response_hop_limit = 1
+    http_tokens                 = "definitely-wrong-not-required"
+  }
+}
+`)
+	assert.Len(t, scanResults, 1)
+}

--- a/internal/app/tfsec/custom/multiple_submatches_test.go
+++ b/internal/app/tfsec/custom/multiple_submatches_test.go
@@ -23,7 +23,7 @@ func init() {
         "action": "isPresent",
         "subMatch": {
 			"action": "and",
-			"childMatchSpec":
+			"predicateMatchSpec":
 				[{
             		"name": "http_endpoint",
             		"action": "equals",

--- a/internal/app/tfsec/custom/multiple_submatches_test.go
+++ b/internal/app/tfsec/custom/multiple_submatches_test.go
@@ -21,23 +21,25 @@ func init() {
       "matchSpec": {
         "name": "metadata_options",
         "action": "isPresent",
-        "subMatches": [
-          {
-            "name": "http_endpoint",
-            "action": "equals",
-            "value": "enabled"
-          },
-          {
-            "name": "http_put_response_hop_limit",
-            "action": "equals",
-            "value": 1
-          },
-          {
-            "name": "http_tokens",
-            "action": "equals",
-            "value": "required"
-          }
-        ]
+        "subMatch": {
+			"action": "and",
+			"childMatchSpec":
+				[{
+            		"name": "http_endpoint",
+            		"action": "equals",
+            		"value": "enabled"
+          		},
+          		{
+            		"name": "http_put_response_hop_limit",
+            		"action": "equals",
+            		"value": 1
+          		},
+          		{
+            		"name": "http_tokens",
+            		"action": "equals",
+            		"value": "required"
+          		}
+        		]}
       }
     }
   ]

--- a/internal/app/tfsec/custom/multiple_submatches_test.go
+++ b/internal/app/tfsec/custom/multiple_submatches_test.go
@@ -22,29 +22,30 @@ func init() {
         "name": "metadata_options",
         "action": "isPresent",
         "subMatch": {
-			"action": "and",
-			"predicateMatchSpec":
-				[{
-            		"name": "http_endpoint",
-            		"action": "equals",
-            		"value": "enabled"
-          		},
-          		{
-            		"name": "http_put_response_hop_limit",
-            		"action": "equals",
-            		"value": 1
-          		},
-          		{
-            		"name": "http_tokens",
-            		"action": "equals",
-            		"value": "required"
-          		}
-        		]}
+          "action": "and",
+          "predicateMatchSpec": [
+            {
+              "name": "http_endpoint",
+              "action": "equals",
+              "value": "enabled"
+            },
+            {
+              "name": "http_put_response_hop_limit",
+              "action": "equals",
+              "value": 1
+            },
+            {
+              "name": "http_tokens",
+              "action": "equals",
+              "value": "required"
+            }
+          ]
+        }
       }
     }
   ]
 }
-    `)
+`)
 }
 
 func TestInstanceMetadataEndpointPresent(t *testing.T) {

--- a/internal/app/tfsec/custom/processing.go
+++ b/internal/app/tfsec/custom/processing.go
@@ -159,6 +159,17 @@ func evalMatchSpec(block *parser.Block, spec *MatchSpec, ctx *scanner.Context) b
 		}
 		evalResult = evalMatchSpec(block, spec.SubMatch, nil)
 	}
+	if len(spec.SubMatches) > 0 {
+		if block.HasBlock(spec.Name) {
+			block = block.GetBlock(spec.Name)
+		}
+		for i := range spec.SubMatches {
+			evalResult = evalMatchSpec(block, &spec.SubMatches[i], nil)
+			if !evalResult {
+				break
+			}
+		}
+	}
 	return evalResult
 }
 

--- a/internal/app/tfsec/custom/processing.go
+++ b/internal/app/tfsec/custom/processing.go
@@ -153,7 +153,7 @@ func evalMatchSpec(block *parser.Block, spec *MatchSpec, ctx *scanner.Context) b
 
 	// This And MatchSpec is only true if all childSpecs return true
 	if spec.Action == And {
-		for _, childSpec := range spec.ChildMatchSpec {
+		for _, childSpec := range spec.PredicateMatchSpec {
 			if !evalMatchSpec(block, &childSpec, ctx) {
 				return false
 			}
@@ -163,7 +163,7 @@ func evalMatchSpec(block *parser.Block, spec *MatchSpec, ctx *scanner.Context) b
 
 	// If a single childSpec is true then this Or matchSpec is true
 	if spec.Action == Or {
-		for _, childSpec := range spec.ChildMatchSpec {
+		for _, childSpec := range spec.PredicateMatchSpec {
 			if evalMatchSpec(block, &childSpec, ctx) {
 				return true
 			}

--- a/internal/app/tfsec/custom/processing.go
+++ b/internal/app/tfsec/custom/processing.go
@@ -154,19 +154,23 @@ func evalMatchSpec(block *parser.Block, spec *MatchSpec, ctx *scanner.Context) b
 	evalResult = matchFunctions[spec.Action](block, spec)
 
 	if spec.SubMatch != nil {
-		if block.HasBlock(spec.Name) {
-			block = block.GetBlock(spec.Name)
-		}
-		evalResult = evalMatchSpec(block, spec.SubMatch, nil)
-	}
-	if len(spec.SubMatches) > 0 {
-		if block.HasBlock(spec.Name) {
-			block = block.GetBlock(spec.Name)
-		}
-		for i := range spec.SubMatches {
-			evalResult = evalMatchSpec(block, &spec.SubMatches[i], nil)
+		for _, block := range block.GetBlocks(spec.Name) {
+			evalResult = evalMatchSpec(block, spec.SubMatch, nil)
 			if !evalResult {
 				break
+			}
+		}
+	}
+
+	if len(spec.SubMatches) > 0 {
+
+	AllBlocks:
+		for _, block := range block.GetBlocks(spec.Name) {
+			for i := range spec.SubMatches {
+				evalResult = evalMatchSpec(block, &spec.SubMatches[i], nil)
+				if !evalResult {
+					break AllBlocks
+				}
 			}
 		}
 	}

--- a/internal/app/tfsec/custom/processing_test.go
+++ b/internal/app/tfsec/custom/processing_test.go
@@ -88,7 +88,6 @@ var testNestedMatchSpec = MatchSpec{
 			},
 		},
 	},
-
 }
 
 func TestRequiresPresenceWithResourcePresent(t *testing.T) {
@@ -128,10 +127,10 @@ resource "aws_vpc" "main" {
 func TestOrMatchFunction(t *testing.T) {
 
 	var tests = []struct {
-		name           string
-		source         string
+		name               string
+		source             string
 		predicateMatchSpec MatchSpec
-		expected       bool
+		expected           bool
 	}{
 		{
 			name: "check `or` match function with no true evaluation",
@@ -140,7 +139,7 @@ resource "aws_ami" "example" {
 }
 `,
 			predicateMatchSpec: testOrMatchSpec,
-			expected:       false,
+			expected:           false,
 		},
 		{
 			name: "check `or` match function with a single true evaluation",
@@ -150,7 +149,7 @@ resource "aws_ami" "example" {
 }
 `,
 			predicateMatchSpec: testOrMatchSpec,
-			expected:       true,
+			expected:           true,
 		},
 		{
 			name: "check `or` match function with all true evaluation",
@@ -161,7 +160,7 @@ resource "aws_ami" "example" {
 }
 `,
 			predicateMatchSpec: testOrMatchSpec,
-			expected:       true,
+			expected:           true,
 		},
 	}
 	for _, test := range tests {
@@ -175,10 +174,10 @@ resource "aws_ami" "example" {
 
 func TestAndMatchFunction(t *testing.T) {
 	var tests = []struct {
-		name           string
-		source         string
+		name               string
+		source             string
 		predicateMatchSpec MatchSpec
-		expected       bool
+		expected           bool
 	}{
 		{
 			name: "check `and` match function with no true evaluation",
@@ -187,7 +186,7 @@ resource "aws_ami" "example" {
 }
 `,
 			predicateMatchSpec: testAndMatchSpec,
-			expected:       false,
+			expected:           false,
 		},
 		{
 			name: "check `and` match function with a single true evaluation",
@@ -197,7 +196,7 @@ resource "aws_ami" "example" {
 }
 `,
 			predicateMatchSpec: testAndMatchSpec,
-			expected:       false,
+			expected:           false,
 		},
 		{
 			name: "check `and` match function with all true evaluation",
@@ -208,7 +207,7 @@ resource "aws_ami" "example" {
 }
 `,
 			predicateMatchSpec: testAndMatchSpec,
-			expected:       true,
+			expected:           true,
 		},
 	}
 	for _, test := range tests {
@@ -221,10 +220,10 @@ resource "aws_ami" "example" {
 }
 func TestNestedMatchFunction(t *testing.T) {
 	var tests = []struct {
-		name           string
-		source         string
+		name               string
+		source             string
 		predicateMatchSpec MatchSpec
-		expected       bool
+		expected           bool
 	}{
 		{
 			name: "check nested match function with only inner true evaluation",
@@ -236,7 +235,7 @@ resource "aws_ami" "example" {
 }
 `,
 			predicateMatchSpec: testNestedMatchSpec,
-			expected:       false,
+			expected:           false,
 		},
 		{
 			name: "check nested match function with no true evaluation",
@@ -246,7 +245,7 @@ resource "aws_ami" "example" {
 }
 `,
 			predicateMatchSpec: testNestedMatchSpec,
-			expected:       false,
+			expected:           false,
 		},
 		{
 			name: "check nested match function with all true evaluation",
@@ -258,7 +257,7 @@ resource "aws_ami" "example" {
 }
 `,
 			predicateMatchSpec: testNestedMatchSpec,
-			expected:       true,
+			expected:           true,
 		},
 	}
 	for _, test := range tests {

--- a/internal/app/tfsec/custom/processing_test.go
+++ b/internal/app/tfsec/custom/processing_test.go
@@ -40,7 +40,7 @@ func init() {
 
 var testOrMatchSpec = MatchSpec{
 	Action: "or",
-	ChildMatchSpec: []MatchSpec{
+	PredicateMatchSpec: []MatchSpec{
 		{
 			Name:   "name",
 			Action: "isPresent",
@@ -54,7 +54,7 @@ var testOrMatchSpec = MatchSpec{
 
 var testAndMatchSpec = MatchSpec{
 	Action: "and",
-	ChildMatchSpec: []MatchSpec{
+	PredicateMatchSpec: []MatchSpec{
 		{
 			Name:   "name",
 			Action: "isPresent",
@@ -68,7 +68,7 @@ var testAndMatchSpec = MatchSpec{
 
 var testNestedMatchSpec = MatchSpec{
 	Action: "and",
-	ChildMatchSpec: []MatchSpec{
+	PredicateMatchSpec: []MatchSpec{
 		{
 			Name:       "virtualization_type",
 			Action:     "equals",
@@ -76,7 +76,7 @@ var testNestedMatchSpec = MatchSpec{
 		},
 		{
 			Action: "or",
-			ChildMatchSpec: []MatchSpec{
+			PredicateMatchSpec: []MatchSpec{
 				{
 					Name:   "image_location",
 					Action: "isPresent",
@@ -130,7 +130,7 @@ func TestOrMatchFunction(t *testing.T) {
 	var tests = []struct {
 		name           string
 		source         string
-		childMatchSpec MatchSpec
+		predicateMatchSpec MatchSpec
 		expected       bool
 	}{
 		{
@@ -139,7 +139,7 @@ func TestOrMatchFunction(t *testing.T) {
 resource "aws_ami" "example" {
 }
 `,
-			childMatchSpec: testOrMatchSpec,
+			predicateMatchSpec: testOrMatchSpec,
 			expected:       false,
 		},
 		{
@@ -149,7 +149,7 @@ resource "aws_ami" "example" {
 	name = "placeholder-name"
 }
 `,
-			childMatchSpec: testOrMatchSpec,
+			predicateMatchSpec: testOrMatchSpec,
 			expected:       true,
 		},
 		{
@@ -160,14 +160,14 @@ resource "aws_ami" "example" {
 	description = "this is a description."
 }
 `,
-			childMatchSpec: testOrMatchSpec,
+			predicateMatchSpec: testOrMatchSpec,
 			expected:       true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			blocks := createBlocksFromSource(test.source)[0]
-			result := evalMatchSpec(blocks, &test.childMatchSpec, nil)
+			result := evalMatchSpec(blocks, &test.predicateMatchSpec, nil)
 			assert.Equal(t, result, test.expected, "`Or` match function evaluating incorrectly.")
 		})
 	}
@@ -177,7 +177,7 @@ func TestAndMatchFunction(t *testing.T) {
 	var tests = []struct {
 		name           string
 		source         string
-		childMatchSpec MatchSpec
+		predicateMatchSpec MatchSpec
 		expected       bool
 	}{
 		{
@@ -186,7 +186,7 @@ func TestAndMatchFunction(t *testing.T) {
 resource "aws_ami" "example" {
 }
 `,
-			childMatchSpec: testAndMatchSpec,
+			predicateMatchSpec: testAndMatchSpec,
 			expected:       false,
 		},
 		{
@@ -196,7 +196,7 @@ resource "aws_ami" "example" {
 	name = "placeholder-name"
 }
 `,
-			childMatchSpec: testAndMatchSpec,
+			predicateMatchSpec: testAndMatchSpec,
 			expected:       false,
 		},
 		{
@@ -207,14 +207,14 @@ resource "aws_ami" "example" {
 	description = "this is a description."
 }
 `,
-			childMatchSpec: testAndMatchSpec,
+			predicateMatchSpec: testAndMatchSpec,
 			expected:       true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			blocks := createBlocksFromSource(test.source)[0]
-			result := evalMatchSpec(blocks, &test.childMatchSpec, nil)
+			result := evalMatchSpec(blocks, &test.predicateMatchSpec, nil)
 			assert.Equal(t, result, test.expected, "`And` match function evaluating incorrectly.")
 		})
 	}
@@ -223,7 +223,7 @@ func TestNestedMatchFunction(t *testing.T) {
 	var tests = []struct {
 		name           string
 		source         string
-		childMatchSpec MatchSpec
+		predicateMatchSpec MatchSpec
 		expected       bool
 	}{
 		{
@@ -235,7 +235,7 @@ resource "aws_ami" "example" {
 	kernel_id = "XXXXXXXXXX"
 }
 `,
-			childMatchSpec: testNestedMatchSpec,
+			predicateMatchSpec: testNestedMatchSpec,
 			expected:       false,
 		},
 		{
@@ -245,7 +245,7 @@ resource "aws_ami" "example" {
 	virtualization_type = "hvm"
 }
 `,
-			childMatchSpec: testNestedMatchSpec,
+			predicateMatchSpec: testNestedMatchSpec,
 			expected:       false,
 		},
 		{
@@ -257,14 +257,14 @@ resource "aws_ami" "example" {
 	kernel_id = "XXXXXXXXXX"
 }
 `,
-			childMatchSpec: testNestedMatchSpec,
+			predicateMatchSpec: testNestedMatchSpec,
 			expected:       true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			blocks := createBlocksFromSource(test.source)[0]
-			result := evalMatchSpec(blocks, &test.childMatchSpec, nil)
+			result := evalMatchSpec(blocks, &test.predicateMatchSpec, nil)
 			assert.Equal(t, result, test.expected, "Nested match functions evaluating incorrectly.")
 		})
 	}

--- a/internal/app/tfsec/custom/processing_test.go
+++ b/internal/app/tfsec/custom/processing_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -35,6 +36,59 @@ func init() {
   ]
 }
 `)
+}
+
+var testOrMatchSpec = MatchSpec{
+	Action: "or",
+	ChildMatchSpec: []MatchSpec{
+		{
+			Name:   "name",
+			Action: "isPresent",
+		},
+		{
+			Name:   "description",
+			Action: "isPresent",
+		},
+	},
+}
+
+var testAndMatchSpec = MatchSpec{
+	Action: "and",
+	ChildMatchSpec: []MatchSpec{
+		{
+			Name:   "name",
+			Action: "isPresent",
+		},
+		{
+			Name:   "description",
+			Action: "isPresent",
+		},
+	},
+}
+
+var testNestedMatchSpec = MatchSpec{
+	Action: "and",
+	ChildMatchSpec: []MatchSpec{
+		{
+			Name:       "virtualization_type",
+			Action:     "equals",
+			MatchValue: "paravirtual",
+		},
+		{
+			Action: "or",
+			ChildMatchSpec: []MatchSpec{
+				{
+					Name:   "image_location",
+					Action: "isPresent",
+				},
+				{
+					Name:   "kernel_id",
+					Action: "isPresent",
+				},
+			},
+		},
+	},
+
 }
 
 func TestRequiresPresenceWithResourcePresent(t *testing.T) {
@@ -71,6 +125,150 @@ resource "aws_vpc" "main" {
 	assert.Len(t, scanResults, 1)
 }
 
+func TestOrMatchFunction(t *testing.T) {
+
+	var tests = []struct {
+		name           string
+		source         string
+		childMatchSpec MatchSpec
+		expected       bool
+	}{
+		{
+			name: "check `or` match function with no true evaluation",
+			source: `
+resource "aws_ami" "example" {
+}
+`,
+			childMatchSpec: testOrMatchSpec,
+			expected:       false,
+		},
+		{
+			name: "check `or` match function with a single true evaluation",
+			source: `
+resource "aws_ami" "example" {
+	name = "placeholder-name"
+}
+`,
+			childMatchSpec: testOrMatchSpec,
+			expected:       true,
+		},
+		{
+			name: "check `or` match function with all true evaluation",
+			source: `
+resource "aws_ami" "example" {
+	name = "placeholder-name"
+	description = "this is a description."
+}
+`,
+			childMatchSpec: testOrMatchSpec,
+			expected:       true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			blocks := createBlocksFromSource(test.source)[0]
+			result := evalMatchSpec(blocks, &test.childMatchSpec, nil)
+			assert.Equal(t, result, test.expected, "`Or` match function evaluating incorrectly.")
+		})
+	}
+}
+
+func TestAndMatchFunction(t *testing.T) {
+	var tests = []struct {
+		name           string
+		source         string
+		childMatchSpec MatchSpec
+		expected       bool
+	}{
+		{
+			name: "check `and` match function with no true evaluation",
+			source: `
+resource "aws_ami" "example" {
+}
+`,
+			childMatchSpec: testAndMatchSpec,
+			expected:       false,
+		},
+		{
+			name: "check `and` match function with a single true evaluation",
+			source: `
+resource "aws_ami" "example" {
+	name = "placeholder-name"
+}
+`,
+			childMatchSpec: testAndMatchSpec,
+			expected:       false,
+		},
+		{
+			name: "check `and` match function with all true evaluation",
+			source: `
+resource "aws_ami" "example" {
+	name = "placeholder-name"
+	description = "this is a description."
+}
+`,
+			childMatchSpec: testAndMatchSpec,
+			expected:       true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			blocks := createBlocksFromSource(test.source)[0]
+			result := evalMatchSpec(blocks, &test.childMatchSpec, nil)
+			assert.Equal(t, result, test.expected, "`And` match function evaluating incorrectly.")
+		})
+	}
+}
+func TestNestedMatchFunction(t *testing.T) {
+	var tests = []struct {
+		name           string
+		source         string
+		childMatchSpec MatchSpec
+		expected       bool
+	}{
+		{
+			name: "check nested match function with only inner true evaluation",
+			source: `
+resource "aws_ami" "example" {
+	virtualization_type = "hvm"
+	image_location = "image-XXXX"
+	kernel_id = "XXXXXXXXXX"
+}
+`,
+			childMatchSpec: testNestedMatchSpec,
+			expected:       false,
+		},
+		{
+			name: "check nested match function with no true evaluation",
+			source: `
+resource "aws_ami" "example" {
+	virtualization_type = "hvm"
+}
+`,
+			childMatchSpec: testNestedMatchSpec,
+			expected:       false,
+		},
+		{
+			name: "check nested match function with all true evaluation",
+			source: `
+resource "aws_ami" "example" {
+	virtualization_type = "paravirtual"
+	image_location = "image-XXXX"
+	kernel_id = "XXXXXXXXXX"
+}
+`,
+			childMatchSpec: testNestedMatchSpec,
+			expected:       true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			blocks := createBlocksFromSource(test.source)[0]
+			result := evalMatchSpec(blocks, &test.childMatchSpec, nil)
+			assert.Equal(t, result, test.expected, "Nested match functions evaluating incorrectly.")
+		})
+	}
+}
 func givenCheck(jsonContent string) {
 	var checksfile ChecksFile
 	err := json.NewDecoder(strings.NewReader(jsonContent)).Decode(&checksfile)
@@ -91,4 +289,29 @@ func scanTerraform(t *testing.T, mainTf string) []scanner.Result {
 	assert.NoError(t, err)
 
 	return scanner.New().Scan(blocks, []string{})
+}
+
+// This function is copied from setup_test.go as it is not possible to import function from test files.
+// TODO: Extract into a testing utility package once the amount of duplication justifies introducing an extra package.
+func createBlocksFromSource(source string) []*parser.Block {
+	path := createTestFile("test.tf", source)
+	blocks, err := parser.New(filepath.Dir(path), "").ParseDirectory()
+	if err != nil {
+		panic(err)
+	}
+	return blocks
+}
+
+// This function is copied from setup_test.go as it is not possible to import function from test files.
+// TODO: Extract into a testing utility package once the amount of duplication justifies introducing an extra package.
+func createTestFile(filename, contents string) string {
+	dir, err := ioutil.TempDir(os.TempDir(), "tfsec")
+	if err != nil {
+		panic(err)
+	}
+	path := filepath.Join(dir, filename)
+	if err := ioutil.WriteFile(path, []byte(contents), 0755); err != nil {
+		panic(err)
+	}
+	return path
 }

--- a/internal/app/tfsec/custom/validate.go
+++ b/internal/app/tfsec/custom/validate.go
@@ -79,10 +79,10 @@ func validateMatchSpec(spec *MatchSpec, check *Check, checkErrors []error) []err
 		checkErrors = append(checkErrors, errors.New("matchSpec.Name requires a value"))
 	}
 
-	// if the check is one of `or`, `and`, then all childMatchSpec's must also be valid
+	// if the check is one of `or`, `and`, then all PredicateMatchSpec's must also be valid
 	if spec.Action == "or" || spec.Action == "and" {
-		for _, childMatchSpec := range spec.ChildMatchSpec {
-			checkErrors = append(validateMatchSpec(&childMatchSpec, check, checkErrors))
+		for _, predicateMatchSpec := range spec.PredicateMatchSpec {
+			checkErrors = append(validateMatchSpec(&predicateMatchSpec, check, checkErrors))
 		}
 	}
 


### PR DESCRIPTION
## Context
Support for `AND` predicates was added as part of https://github.com/tfsec/tfsec/pull/580. 

## Intent
To re-work the current implementation for composite checks.

## Problem
The major downsides we found with the current implementation are:
- Some custom checks may benefit from an `or` operator being available.
- The implicit `and` behavior of `subMatches` is not apparent from the check definition files. In consequence, non-experienced users will struggle to understand/write checks without having to refer to the official documentation or rely on their teams' tribal knowledge.
- The `subMatch` / `subMatches` operator is a bit overloaded with too many responsibilities:
    -  Provide the ability to “look into” a nested block. 
    -  Provide support for `and`-based composite boolean expressions.

## Proposed Solution
To adopt a new implementation for composite checks that supports both `and` and `or` operators, it is explicitly visible from the check definition files, and do not overload the `subMatch` operator keeping the `chekFunctions` as atomic as possible.

As you can see from the check_all_statements_test.go file, it will still be possible to provide the same functionality that `subMatches` had provided, while allowing for general checkFunctions to be combined. 

(cc: @muplim)