### PR TITLE
Adds support for detailed exit code

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -172,26 +172,13 @@ var rootCmd = &cobra.Command{
 		}
 
 		// Soft fail always takes precedence. If set, only execution errors
-		// produce failure exit codes.
+		// produce a failure exit code (1).
 		if softFail {
 			os.Exit(0)
 		}
 
 		if detailedExitCode {
-			// If there are no failed checks, then produce a success exit code (0).
-			if len(results) == 0 {
-				os.Exit(0)
-			}
-
-			// If there are some failed checks but they are all of INFO severity, then
-			// produce a special failure exit code (2).
-			if allInfo(results) {
-				os.Exit(2)
-			}
-
-			// If there is any failed check of ERROR or WARNING severity, then
-			// produce the regular failure exit code (1).
-			os.Exit(1)
+			os.Exit(getDetailedExitCode(results))
 		}
 
 		// If all failed checks are of INFO severity, then produce a success
@@ -202,6 +189,23 @@ var rootCmd = &cobra.Command{
 
 		os.Exit(1)
 	},
+}
+
+func getDetailedExitCode(results []scanner.Result) int {
+	// If there are no failed checks, then produce a success exit code (0).
+	if len(results) == 0 {
+		return 0
+	}
+
+	// If there are some failed checks but they are all of INFO severity, then
+	// produce a special failure exit code (2).
+	if allInfo(results) {
+		return 2
+	}
+
+	// If there is any failed check of ERROR or WARNING severity, then
+	// produce the regular failure exit code (1).
+	return 1
 }
 
 func removeDuplicatesAndUnwanted(results []scanner.Result) []scanner.Result {

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -36,6 +36,7 @@ var configFile string
 var tfsecConfig = &config.Config{}
 var conciseOutput = false
 var excludeDownloaded = false
+var detailedExitCode = false
 
 func init() {
 	rootCmd.Flags().BoolVar(&disableColours, "no-colour", disableColours, "Disable coloured output")
@@ -51,6 +52,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&debug.Enabled, "verbose", debug.Enabled, "Enable verbose logging")
 	rootCmd.Flags().BoolVar(&conciseOutput, "concise-output", conciseOutput, "Reduce the amount of output and no statistics")
 	rootCmd.Flags().BoolVar(&excludeDownloaded, "exclude-downloaded-modules", excludeDownloaded, "Remove results for downloaded modules in .terraform folder")
+	rootCmd.Flags().BoolVar(&detailedExitCode, "detailed-exit-code", detailedExitCode, "Produce more detailed exit status codes.")
 }
 
 func main() {
@@ -169,7 +171,32 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if allInfo(results) || softFail {
+		// Soft fail always takes precedence. If set, only execution errors
+		// produce failure exit codes.
+		if softFail {
+			os.Exit(0)
+		}
+
+		if detailedExitCode {
+			// If there are no failed checks, then produce a success exit code (0).
+			if len(results) == 0 {
+				os.Exit(0)
+			}
+
+			// If there are some failed checks but they are all of INFO severity, then
+			// produce a special failure exit code (2).
+			if allInfo(results) {
+				os.Exit(2)
+			}
+
+			// If there is any failed check of ERROR or WARNING severity, then
+			// produce the regular failure exit code (1).
+			os.Exit(1)
+		}
+
+		// If all failed checks are of INFO severity, then produce a success
+		// exit code (0).
+		if allInfo(results)  {
 			os.Exit(0)
 		}
 
@@ -222,7 +249,6 @@ func allInfo(results []scanner.Result) bool {
 			return false
 		}
 	}
-
 	return true
 }
 


### PR DESCRIPTION
## Intent
To introduce `--detailed-exit-code` so that it is possible to know that a `tfsec` run has produced `INFO` messages.

## Problem
Some CI/CD providers such as `Buildkite` allow expanding each step's logs view as soon as an error occurs. This is an awesome feature as it helps to minimize the log spam noise. 

See: https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output

With the current implementation of `tfsec`, it is impossible to tell whether an execution passed all the checks or it only failed `INFO`-level checks.

This isn't perfect as we believe that `INFO`-level checks should still be reported to the user.

## Solution
To introduce a new CLI flag (`--detailed-exit-code`) that, when set, produces more informative exit codes to differentiate the following scenarios:

| Exit code       | Execution Result |
| ------------- |:-------------:|
| 0  | All checks succeeded | 
| 1 |  Either the execution of `tfsec` failed or some checks with severity `ERROR` or `WARNING` failed. |
| 2 | The execution of `tfsec` succeeded but some checks with severity `INFO` failed. |

## Note
The `softfail` flag has been given preference to keep backward compatibility with previous releases.