### PR TITLE
AZU017 Should not trigger when access mode is Deny

### DIFF
--- a/internal/app/tfsec/checks/azu017.go
+++ b/internal/app/tfsec/checks/azu017.go
@@ -91,7 +91,7 @@ func init() {
 			}
 
 			for _, rule := range securityRules {
-				if rule.HasChild("access") && rule.GetAttribute("access").Contains("Deny") {
+				if rule.HasChild("access") && rule.GetAttribute("access").Equals("Deny") {
 					return nil
 				}
 				if rule.HasChild("destination_port_range") && rule.GetAttribute("destination_port_range").Contains("22") {

--- a/internal/app/tfsec/checks/azu017.go
+++ b/internal/app/tfsec/checks/azu017.go
@@ -91,6 +91,9 @@ func init() {
 			}
 
 			for _, rule := range securityRules {
+				if rule.HasChild("access") && rule.GetAttribute("access").Contains("Deny") {
+					return nil
+				}
 				if rule.HasChild("destination_port_range") && rule.GetAttribute("destination_port_range").Contains("22") {
 					if rule.HasChild("source_address_prefix") {
 						if rule.GetAttribute("source_address_prefix").IsAny("*", "0.0.0.0", "/0", "internet", "any") {

--- a/internal/app/tfsec/checks/azu017.go
+++ b/internal/app/tfsec/checks/azu017.go
@@ -91,7 +91,7 @@ func init() {
 			}
 
 			for _, rule := range securityRules {
-				if rule.HasChild("access") && rule.GetAttribute("access").Equals("Deny") {
+				if rule.HasChild("access") && rule.GetAttribute("access").Equals("Deny", parser.IgnoreCase) {
 					return nil
 				}
 				if rule.HasChild("destination_port_range") && rule.GetAttribute("destination_port_range").Contains("22") {

--- a/internal/app/tfsec/test/azu017_test.go
+++ b/internal/app/tfsec/test/azu017_test.go
@@ -139,7 +139,7 @@ resource "azurerm_network_security_group" "example_deny" {
   
   security_rule {
      access                      = "Deny"
-	 source_port_range           = "any"
+     source_port_range           = "any"
      destination_port_range      = ["22", "80", "443"]
      source_address_prefix       = "*"
      destination_address_prefix  = "*"

--- a/internal/app/tfsec/test/azu017_test.go
+++ b/internal/app/tfsec/test/azu017_test.go
@@ -32,6 +32,22 @@ resource "azurerm_network_security_rule" "bad_example" {
 			mustIncludeResultCode: checks.AZUSSHAccessNotAllowedFromInternet,
 		},
 		{
+			name: "check ssh access from * is ok when mode is deny",
+			source: `
+resource "azurerm_network_security_rule" "example_deny" {
+     name                        = "example_deny_security_rule"
+     direction                   = "Inbound"
+     access                      = "Deny"
+     protocol                    = "TCP"
+     source_port_range           = "*"
+     destination_port_range      = ["22"]
+     source_address_prefix       = "*"
+     destination_address_prefix  = "*"
+}
+`,
+			mustExcludeResultCode: checks.AZUSSHAccessNotAllowedFromInternet,
+		},
+		{
 			name: "check ssh access from 0.0.0.0 causes a failure",
 			source: `
 resource "azurerm_network_security_rule" "bad_example" {
@@ -112,6 +128,25 @@ resource "azurerm_network_security_group" "example" {
 }
 `,
 			mustIncludeResultCode: checks.AZUSSHAccessNotAllowedFromInternet,
+		},
+		{
+			name: "check ssh access from * is ok when access mode is deny",
+			source: `
+resource "azurerm_network_security_group" "example_deny" {
+  name                = "tf-appsecuritygroup"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  
+  security_rule {
+     access                      = "Deny"
+	 source_port_range           = "any"
+     destination_port_range      = ["22", "80", "443"]
+     source_address_prefix       = "*"
+     destination_address_prefix  = "*"
+  }
+}
+`,
+			mustExcludeResultCode: checks.AZUSSHAccessNotAllowedFromInternet,
 		},
 		{
 			name: "check ssh access from multiple security rules causes a failure on security group",


### PR DESCRIPTION
This example below should not trigger `AZU017` warning. PR adds a check to see if the access mode is Deny and doesn't warn in that case.

```
resource "azurerm_network_security_rule" "deny-ssh" {
  name                        = "ssh-deny-all"
  priority                    = 1000
  direction                   = "Inbound"
  access                      = "Deny"
  protocol                    = "Tcp"
  source_port_range           = "*"
  destination_port_range      = "22"
  source_address_prefix       = "*"
  destination_address_prefix  = "*"
  resource_group_name         = azurerm_resource_group.example.name
  network_security_group_name = azurerm_network_security_group.example.name
}
```

Results in:
```
Problem 1

  [AZU017][ERROR] Resource 'azurerm_network_security_rule.deny-ssh' has a .
  /Users/hkotka/tmp/main.tf:1-13

       1 | resource "azurerm_network_security_rule" "deny-ssh" {
       2 |   name                        = "ssh-deny-all"
       3 |   priority                    = 1000
       4 |   direction                   = "Inbound"
       5 |   access                      = "Deny"
       6 |   protocol                    = "Tcp"
       7 |   source_port_range           = "*"
       8 |   destination_port_range      = "22"
       9 |   source_address_prefix       = "*"
      10 |   destination_address_prefix  = "*"
      11 |   resource_group_name         = azurerm_resource_group.example.name
      12 |   network_security_group_name = azurerm_network_security_group.example.name
      13 | }
      14 |

   See https://tfsec.dev/docs/azure/AZU017/ for more information.
```