### PR TITLE
Fix AWS051 `value is null` warning

### DIFF
--- a/internal/app/tfsec/checks/aws051.go
+++ b/internal/app/tfsec/checks/aws051.go
@@ -47,7 +47,7 @@ func init() {
 			kmsKeyIdAttr := block.GetAttribute("kms_key_id")
 			storageEncryptedattr := block.GetAttribute("storage_encrypted")
 
-			if kmsKeyIdAttr == nil {
+			if kmsKeyIdAttr == nil || kmsKeyIdAttr.Value().IsNull() {
 				return []scanner.Result{
 					check.NewResult(
 						fmt.Sprintf("Resource '%s' defines a disabled RDS Cluster encryption.", block.FullName()),

--- a/internal/app/tfsec/test/aws051_test.go
+++ b/internal/app/tfsec/test/aws051_test.go
@@ -45,6 +45,17 @@ resource "aws_rds_cluster" "my-instance" {
 			mustIncludeResultCode: checks.AWSRDSAuroraClusterEncryptionDisabled,
 		},
 		{
+			name: "check rds storage_encrypted is false and key_id is null",
+			source: `
+resource "aws_rds_cluster" "my-instance" {
+	name       = "cluster-1"
+	storage_encrypted = false
+	kms_key_id = null
+}
+`,
+			mustIncludeResultCode: checks.AWSRDSAuroraClusterEncryptionDisabled,
+		},
+		{
 			name: "check rds encryption is enabled correctly",
 			source: `
 resource "aws_rds_cluster" "my-instance" {


### PR DESCRIPTION
When `aws_rds_cluster` attribute `kms_key_id` was explicitly set to
`null`, tfsec did not catch the disabled encryption and issued a
warning:

> WARNING: skipped AWS051 check due to error(s): value is null

The added test case reproduces this issue.

**Note**: The test case does not _catch_ the issue though, as the test execution
logic seems to differ from the real scanning logic, in that it doesn't
try to format the result.