### PR TITLE
Add --include-passed flag to add passed checks to result output.

### DIFF
--- a/internal/app/tfsec/checks/aws001.go
+++ b/internal/app/tfsec/checks/aws001.go
@@ -50,7 +50,7 @@ func init() {
 				acl := attr.Value().AsString()
 				if acl == "public-read" || acl == "public-read-write" || acl == "website" {
 					return []scanner.Result{
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' has an ACL which allows public access.", block.FullName()),
 							attr.Range(),
 							attr,
@@ -60,7 +60,7 @@ func init() {
 				}
 				if acl == "authenticated-read" {
 					return []scanner.Result{
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' has an ACL which allows access to any authenticated AWS user, not just users within the target account.", block.FullName()),
 							attr.Range(),
 							attr,
@@ -69,7 +69,7 @@ func init() {
 					}
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws002.go
+++ b/internal/app/tfsec/checks/aws002.go
@@ -45,17 +45,17 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if loggingBlock := block.GetBlock("logging"); loggingBlock == nil {
 				if block.GetAttribute("acl") != nil && block.GetAttribute("acl").Value().AsString() == "log-delivery-write" {
-					return nil
+					return []scanner.Result{check.NewPassingResult(block.Range())}
 				}
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not have logging enabled.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws003.go
+++ b/internal/app/tfsec/checks/aws003.go
@@ -42,7 +42,7 @@ func init() {
 		RequiredLabels: []string{"aws_db_security_group", "aws_redshift_security_group", "aws_elasticache_security_group"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			return []scanner.Result{
-				check.NewResult(
+				check.NewFailingResult(
 					fmt.Sprintf("Resource '%s' uses EC2 Classic. Use a VPC instead.", block.FullName()),
 					block.Range(),
 					scanner.SeverityError,

--- a/internal/app/tfsec/checks/aws004.go
+++ b/internal/app/tfsec/checks/aws004.go
@@ -53,7 +53,7 @@ func init() {
 						if redirectBlock := actionBlock.GetBlock("redirect"); redirectBlock != nil {
 							redirectProtocolAttr := redirectBlock.GetAttribute("protocol")
 							if redirectProtocolAttr != nil && redirectProtocolAttr.Type() == cty.String && redirectProtocolAttr.Value().AsString() == "HTTPS" {
-								return nil
+								return []scanner.Result{check.NewPassingResult(block.Range())}
 							}
 						}
 					}
@@ -63,7 +63,7 @@ func init() {
 					reportRange = protocolAttr.Range()
 				}
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' uses plain HTTP instead of HTTPS.", block.FullName()),
 						reportRange,
 						protocolAttr,
@@ -71,7 +71,7 @@ func init() {
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws005.go
+++ b/internal/app/tfsec/checks/aws005.go
@@ -44,7 +44,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if internalAttr := block.GetAttribute("internal"); internalAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' is exposed publicly.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -52,7 +52,7 @@ func init() {
 				}
 			} else if internalAttr.Type() == cty.Bool && internalAttr.Value().False() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' is exposed publicly.", block.FullName()),
 						internalAttr.Range(),
 						internalAttr,
@@ -60,7 +60,7 @@ func init() {
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws006.go
+++ b/internal/app/tfsec/checks/aws006.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 
 	"github.com/zclconf/go-cty/cty"
@@ -46,18 +47,18 @@ func init() {
 
 			typeAttr := block.GetAttribute("type")
 			if typeAttr == nil || typeAttr.Type() != cty.String {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if typeAttr.Value().AsString() != "ingress" {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if cidrBlocksAttr := block.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
 
 				if isOpenCidr(cidrBlocksAttr, check.Provider) {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", block.FullName()),
 							cidrBlocksAttr.Range(),
 							scanner.SeverityWarning,
@@ -71,7 +72,7 @@ func init() {
 
 				if isOpenCidr(ipv6CidrBlocksAttr, check.Provider) {
 					return []scanner.Result{
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", block.FullName()),
 							ipv6CidrBlocksAttr.Range(),
 							ipv6CidrBlocksAttr,
@@ -82,7 +83,7 @@ func init() {
 
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws007.go
+++ b/internal/app/tfsec/checks/aws007.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
@@ -45,18 +46,18 @@ func init() {
 
 			typeAttr := block.GetAttribute("type")
 			if typeAttr == nil || typeAttr.Type() != cty.String {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if typeAttr.Value().AsString() != "egress" {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if cidrBlocksAttr := block.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
 
 				if isOpenCidr(cidrBlocksAttr, check.Provider) {
 					return []scanner.Result{
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' defines a fully open egress security group rule.", block.FullName()),
 							cidrBlocksAttr.Range(),
 							cidrBlocksAttr,
@@ -70,7 +71,7 @@ func init() {
 
 				if isOpenCidr(ipv6CidrBlocksAttr, check.Provider) {
 					return []scanner.Result{
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' defines a fully open egress security group rule.", block.FullName()),
 							ipv6CidrBlocksAttr.Range(),
 							ipv6CidrBlocksAttr,
@@ -80,7 +81,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws008.go
+++ b/internal/app/tfsec/checks/aws008.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
@@ -51,7 +52,7 @@ func init() {
 
 					if isOpenCidr(cidrBlocksAttr, check.Provider) {
 						results = append(results,
-							check.NewResult(
+							check.NewFailingResult(
 								fmt.Sprintf("Resource '%s' defines a fully open ingress security group.", block.FullName()),
 								cidrBlocksAttr.Range(),
 								scanner.SeverityWarning,
@@ -64,7 +65,7 @@ func init() {
 
 					if isOpenCidr(cidrBlocksAttr, check.Provider) {
 						results = append(results,
-							check.NewResult(
+							check.NewFailingResult(
 								fmt.Sprintf("Resource '%s' defines a fully open ingress security group.", block.FullName()),
 								cidrBlocksAttr.Range(),
 								scanner.SeverityWarning,

--- a/internal/app/tfsec/checks/aws009.go
+++ b/internal/app/tfsec/checks/aws009.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -50,7 +51,7 @@ func init() {
 
 					if isOpenCidr(cidrBlocksAttr, check.Provider) {
 						results = append(results,
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf("Resource '%s' defines a fully open egress security group.", block.FullName()),
 								cidrBlocksAttr.Range(),
 								cidrBlocksAttr,
@@ -64,7 +65,7 @@ func init() {
 
 					if isOpenCidr(cidrBlocksAttr, check.Provider) {
 						results = append(results,
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf("Resource '%s' defines a fully open egress security group.", block.FullName()),
 								cidrBlocksAttr.Range(),
 								cidrBlocksAttr,

--- a/internal/app/tfsec/checks/aws010.go
+++ b/internal/app/tfsec/checks/aws010.go
@@ -57,7 +57,7 @@ func init() {
 				for _, policy := range outdatedSSLPolicies {
 					if policy == sslPolicyAttr.Value().AsString() {
 						return []scanner.Result{
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf("Resource '%s' is using an outdated SSL policy.", block.FullName()),
 								sslPolicyAttr.Range(),
 								sslPolicyAttr,
@@ -68,7 +68,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws011.go
+++ b/internal/app/tfsec/checks/aws011.go
@@ -46,7 +46,7 @@ func init() {
 			if publicAttr := block.GetAttribute("publicly_accessible"); publicAttr != nil && publicAttr.Type() == cty.Bool {
 				if publicAttr.Value().True() {
 					return []scanner.Result{
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' is exposed publicly.", block.FullName()),
 							publicAttr.Range(),
 							publicAttr,
@@ -56,7 +56,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws012.go
+++ b/internal/app/tfsec/checks/aws012.go
@@ -44,7 +44,7 @@ func init() {
 			if publicAttr := block.GetAttribute("associate_public_ip_address"); publicAttr != nil && publicAttr.Type() == cty.Bool {
 				if publicAttr.Value().True() {
 					return []scanner.Result{
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' has a public IP address associated.", block.FullName()),
 							publicAttr.Range(),
 							publicAttr,
@@ -54,7 +54,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws013.go
+++ b/internal/app/tfsec/checks/aws013.go
@@ -85,13 +85,13 @@ func init() {
 				}
 
 				if err := json.Unmarshal(rawJSON, &definitions); err != nil {
-					return nil
+					return []scanner.Result{check.NewPassingResult(block.Range())}
 				}
 
 				for _, definition := range definitions {
 					for _, env := range definition.EnvVars {
 						if security.IsSensitiveAttribute(env.Name) && env.Value != "" {
-							results = append(results, check.NewResultWithValueAnnotation(
+							results = append(results, check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf("Resource '%s' includes a potentially sensitive environment variable '%s' in the container definition.", block.FullName(), env.Name),
 								definitionsAttr.Range(),
 								definitionsAttr,

--- a/internal/app/tfsec/checks/aws014.go
+++ b/internal/app/tfsec/checks/aws014.go
@@ -59,7 +59,7 @@ func init() {
 			rootDeviceBlock := block.GetBlock("root_block_device")
 			if rootDeviceBlock == nil && !encryptionByDefault {
 				results = append(results,
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' uses an unencrypted root EBS block device. Consider adding <blue>root_block_device{ encrypted = true }</blue>", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -69,7 +69,7 @@ func init() {
 				encryptedAttr := rootDeviceBlock.GetAttribute("encrypted")
 				if encryptedAttr == nil && !encryptionByDefault {
 					results = append(results,
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' uses an unencrypted root EBS block device. Consider adding <blue>encrypted = true</blue>", block.FullName()),
 							rootDeviceBlock.Range(),
 							scanner.SeverityError,
@@ -77,7 +77,7 @@ func init() {
 					)
 				} else if encryptedAttr != nil && encryptedAttr.Type() == cty.Bool && encryptedAttr.Value().False() {
 					results = append(results,
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' uses an unencrypted root EBS block device.", block.FullName()),
 							encryptedAttr.Range(),
 							encryptedAttr,
@@ -92,7 +92,7 @@ func init() {
 				encryptedAttr := ebsDeviceBlock.GetAttribute("encrypted")
 				if encryptedAttr == nil && !encryptionByDefault {
 					results = append(results,
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' uses an unencrypted EBS block device. Consider adding <blue>encrypted = true</blue>", block.FullName()),
 							ebsDeviceBlock.Range(),
 							scanner.SeverityError,
@@ -100,7 +100,7 @@ func init() {
 					)
 				} else if encryptedAttr != nil && encryptedAttr.Type() == cty.Bool && encryptedAttr.Value().False() {
 					results = append(results,
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' uses an unencrypted EBS block device.", block.FullName()),
 							encryptedAttr.Range(),
 							encryptedAttr,

--- a/internal/app/tfsec/checks/aws015.go
+++ b/internal/app/tfsec/checks/aws015.go
@@ -44,7 +44,7 @@ func init() {
 			kmsKeyIDAttr := block.GetAttribute("kms_master_key_id")
 			if kmsKeyIDAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted SQS queue.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -52,7 +52,7 @@ func init() {
 				}
 			} else if kmsKeyIDAttr.Type() == cty.String && kmsKeyIDAttr.Value().AsString() == "" {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' defines an unencrypted SQS queue.", block.FullName()),
 						kmsKeyIDAttr.Range(),
 						kmsKeyIDAttr,
@@ -61,7 +61,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws016.go
+++ b/internal/app/tfsec/checks/aws016.go
@@ -44,7 +44,7 @@ func init() {
 			kmsKeyIDAttr := block.GetAttribute("kms_master_key_id")
 			if kmsKeyIDAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted SNS topic.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -52,7 +52,7 @@ func init() {
 				}
 			} else if kmsKeyIDAttr.Type() == cty.String && kmsKeyIDAttr.Value().AsString() == "" {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' defines an unencrypted SNS topic.", block.FullName()),
 						kmsKeyIDAttr.Range(),
 						kmsKeyIDAttr,
@@ -61,7 +61,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws017.go
+++ b/internal/app/tfsec/checks/aws017.go
@@ -50,7 +50,7 @@ func init() {
 
 			if block.MissingChild("server_side_encryption_configuration") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing server_side_encryption_configuration block).", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -60,7 +60,7 @@ func init() {
 			encryptionBlock := block.GetBlock("server_side_encryption_configuration")
 			if encryptionBlock.MissingChild("rule") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing rule block).", block.FullName()),
 						encryptionBlock.Range(),
 						scanner.SeverityError,
@@ -72,7 +72,7 @@ func init() {
 
 			if ruleBlock.MissingChild("apply_server_side_encryption_by_default") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing apply_server_side_encryption_by_default block).", block.FullName()),
 						ruleBlock.Range(),
 						scanner.SeverityError,
@@ -83,7 +83,7 @@ func init() {
 			applyBlock := ruleBlock.GetBlock("apply_server_side_encryption_by_default")
 			if sseAttr := applyBlock.GetAttribute("sse_algorithm"); sseAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing sse_algorithm attribute).", block.FullName()),
 						applyBlock.Range(),
 						scanner.SeverityError,
@@ -91,7 +91,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws018.go
+++ b/internal/app/tfsec/checks/aws018.go
@@ -64,7 +64,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if block.MissingChild("description") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' should include a description for auditing purposes.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -75,7 +75,7 @@ func init() {
 			descriptionAttr := block.GetAttribute("description")
 			if descriptionAttr.IsEmpty() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' should include a non-empty description for auditing purposes.", block.FullName()),
 						descriptionAttr.Range(),
 						descriptionAttr,
@@ -83,7 +83,7 @@ func init() {
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws019.go
+++ b/internal/app/tfsec/checks/aws019.go
@@ -44,14 +44,14 @@ func init() {
 			keyUsageAttr := block.GetAttribute("key_usage")
 
 			if keyUsageAttr != nil && keyUsageAttr.Equals("SIGN_VERIFY") {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			keyRotationAttr := block.GetAttribute("enable_key_rotation")
 
 			if keyRotationAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not have KMS Key auto-rotation enabled.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -61,7 +61,7 @@ func init() {
 
 			if keyRotationAttr.Type() == cty.Bool && keyRotationAttr.Value().False() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' does not have KMS Key auto-rotation enabled.", block.FullName()),
 						keyRotationAttr.Range(),
 						keyRotationAttr,
@@ -70,7 +70,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws020.go
+++ b/internal/app/tfsec/checks/aws020.go
@@ -52,7 +52,7 @@ func init() {
 			defaultBehaviorBlock := block.GetBlock("default_cache_behavior")
 			if defaultBehaviorBlock == nil {
 				results = append(results,
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications (missing default_cache_behavior block).", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -62,7 +62,7 @@ func init() {
 				protocolPolicy := defaultBehaviorBlock.GetAttribute("viewer_protocol_policy")
 				if protocolPolicy == nil {
 					results = append(results,
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications (missing viewer_protocol_policy block).", block.FullName()),
 							block.Range(),
 							scanner.SeverityError,
@@ -70,7 +70,7 @@ func init() {
 					)
 				} else if protocolPolicy.Type() == cty.String && protocolPolicy.Value().AsString() == "allow-all" {
 					results = append(results,
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications.", block.FullName()),
 							protocolPolicy.Range(),
 							protocolPolicy,
@@ -85,7 +85,7 @@ func init() {
 				orderedProtocolPolicy := orderedBehaviorBlock.GetAttribute("viewer_protocol_policy")
 				if orderedProtocolPolicy == nil {
 					results = append(results,
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications (missing viewer_protocol_policy block).", block.FullName()),
 							block.Range(),
 							scanner.SeverityError,
@@ -93,7 +93,7 @@ func init() {
 					)
 				} else if orderedProtocolPolicy != nil && orderedProtocolPolicy.Type() == cty.String && orderedProtocolPolicy.Value().AsString() == "allow-all" {
 					results = append(results,
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications.", block.FullName()),
 							orderedProtocolPolicy.Range(),
 							orderedProtocolPolicy,

--- a/internal/app/tfsec/checks/aws021.go
+++ b/internal/app/tfsec/checks/aws021.go
@@ -49,7 +49,7 @@ func init() {
 			viewerCertificateBlock := block.GetBlock("viewer_certificate")
 			if viewerCertificateBlock == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (missing viewer_certificate block)", block.FullName()),
 						viewerCertificateBlock.Range(),
 						scanner.SeverityError,
@@ -59,7 +59,7 @@ func init() {
 
 			if minVersion := viewerCertificateBlock.GetAttribute("minimum_protocol_version"); minVersion == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (missing minimum_protocol_version attribute)", block.FullName()),
 						viewerCertificateBlock.Range(),
 						scanner.SeverityError,
@@ -67,14 +67,14 @@ func init() {
 				}
 			} else if minVersion.Type() == cty.String && minVersion.Value().AsString() != "TLSv1.2_2019" {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (not using TLSv1.2_2019)", block.FullName()),
 						minVersion.Range(),
 						scanner.SeverityError,
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws022.go
+++ b/internal/app/tfsec/checks/aws022.go
@@ -55,7 +55,7 @@ func init() {
 			defaultBehaviorBlock := block.GetBlock("encryption_info")
 			if defaultBehaviorBlock == nil {
 				results = append(results,
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing encryption_info block).", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -65,7 +65,7 @@ func init() {
 				encryptionInTransit := defaultBehaviorBlock.GetBlock("encryption_in_transit")
 				if encryptionInTransit == nil {
 					results = append(results,
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing encryption_in_transit block).", block.FullName()),
 							block.Range(),
 							scanner.SeverityWarning,
@@ -75,7 +75,7 @@ func init() {
 					clientBroker := encryptionInTransit.GetAttribute("client_broker")
 					if clientBroker == nil {
 						results = append(results,
-							check.NewResult(
+							check.NewFailingResult(
 								fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing client_broker block).", block.FullName()),
 								block.Range(),
 								scanner.SeverityWarning,
@@ -83,7 +83,7 @@ func init() {
 						)
 					} else if clientBroker != nil && clientBroker.Value().AsString() == "PLAINTEXT" {
 						results = append(results,
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf("Resource '%s' defines a MSK cluster that only allows plaintext data in transit.", block.FullName()),
 								clientBroker.Range(),
 								clientBroker,
@@ -92,7 +92,7 @@ func init() {
 						)
 					} else if clientBroker != nil && clientBroker.Value().AsString() == "TLS_PLAINTEXT" {
 						results = append(results,
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit.", block.FullName()),
 								clientBroker.Range(),
 								clientBroker,

--- a/internal/app/tfsec/checks/aws023.go
+++ b/internal/app/tfsec/checks/aws023.go
@@ -57,7 +57,7 @@ func init() {
 
 			if ecrScanStatusAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a disabled ECR image scan.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -65,7 +65,7 @@ func init() {
 				}
 			} else if ecrScanStatusAttr.Type() == cty.Bool && ecrScanStatusAttr.Value().False() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' defines a disabled ECR image scan.", block.FullName()),
 						ecrScanStatusAttr.Range(),
 						ecrScanStatusAttr,
@@ -73,7 +73,7 @@ func init() {
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws024.go
+++ b/internal/app/tfsec/checks/aws024.go
@@ -46,7 +46,7 @@ func init() {
 			encryptionTypeAttr := block.GetAttribute("encryption_type")
 			if encryptionTypeAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted Kinesis Stream.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -54,7 +54,7 @@ func init() {
 				}
 			} else if encryptionTypeAttr.Type() == cty.String && strings.ToUpper(encryptionTypeAttr.Value().AsString()) != "KMS" {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' defines an unencrypted Kinesis Stream.", block.FullName()),
 						encryptionTypeAttr.Range(),
 						encryptionTypeAttr,
@@ -65,7 +65,7 @@ func init() {
 				keyIDAttr := block.GetAttribute("kms_key_id")
 				if keyIDAttr == nil || keyIDAttr.Value().AsString() == "" || keyIDAttr.Value().AsString() == "alias/aws/kinesis" {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defines a Kinesis Stream encrypted with the default Kinesis key.", block.FullName()),
 							block.Range(),
 							scanner.SeverityWarning,
@@ -74,7 +74,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws025.go
+++ b/internal/app/tfsec/checks/aws025.go
@@ -43,7 +43,7 @@ func init() {
 			securityPolicyAttr := block.GetAttribute("security_policy")
 			if securityPolicyAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' should include security_policy (defauls to outdated SSL/TLS policy).", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -53,7 +53,7 @@ func init() {
 
 			if securityPolicyAttr.Type() == cty.String && securityPolicyAttr.Value().AsString() != "TLS_1_2" {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (not using TLS_1_2).", block.FullName()),
 						securityPolicyAttr.Range(),
 						securityPolicyAttr,
@@ -62,7 +62,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws031.go
+++ b/internal/app/tfsec/checks/aws031.go
@@ -52,7 +52,7 @@ func init() {
 			encryptionBlock := block.GetBlock("encrypt_at_rest")
 			if encryptionBlock == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted Elasticsearch domain (missing encrypt_at_rest block).", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -63,7 +63,7 @@ func init() {
 			enabledAttr := encryptionBlock.GetAttribute("enabled")
 			if enabledAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted Elasticsearch domain (missing enabled attribute).", block.FullName()),
 						encryptionBlock.Range(),
 						scanner.SeverityError,
@@ -77,7 +77,7 @@ func init() {
 			encryptionEnabled := isTrueBool || isTrueString
 			if !encryptionEnabled {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted Elasticsearch domain (enabled attribute set to false).", block.FullName()),
 						encryptionBlock.Range(),
 						scanner.SeverityError,
@@ -85,7 +85,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws032.go
+++ b/internal/app/tfsec/checks/aws032.go
@@ -53,7 +53,7 @@ func init() {
 			encryptionBlock := block.GetBlock("node_to_node_encryption")
 			if encryptionBlock == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing node_to_node_encryption block).", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -64,7 +64,7 @@ func init() {
 			enabledAttr := encryptionBlock.GetAttribute("enabled")
 			if enabledAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing enabled attribute).", block.FullName()),
 						encryptionBlock.Range(),
 						scanner.SeverityError,
@@ -78,7 +78,7 @@ func init() {
 			nodeToNodeEncryptionEnabled := isTrueBool || isTrueString
 			if !nodeToNodeEncryptionEnabled {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (enabled attribute set to false).", block.FullName()),
 						encryptionBlock.Range(),
 						scanner.SeverityError,
@@ -86,7 +86,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws033.go
+++ b/internal/app/tfsec/checks/aws033.go
@@ -56,7 +56,7 @@ func init() {
 			endpointBlock := block.GetBlock("domain_endpoint_options")
 			if endpointBlock == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing domain_endpoint_options block).", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -67,7 +67,7 @@ func init() {
 			enforceHTTPSAttr := endpointBlock.GetAttribute("enforce_https")
 			if enforceHTTPSAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing enforce_https attribute).", block.FullName()),
 						endpointBlock.Range(),
 						scanner.SeverityError,
@@ -81,7 +81,7 @@ func init() {
 			enforcedHTTPS := isTrueBool || isTrueString
 			if !enforcedHTTPS {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (enabled attribute set to false).", block.FullName()),
 						endpointBlock.Range(),
 						scanner.SeverityError,
@@ -89,7 +89,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws034.go
+++ b/internal/app/tfsec/checks/aws034.go
@@ -54,25 +54,25 @@ func init() {
 			endpointBlock := block.GetBlock("domain_endpoint_options")
 			if endpointBlock == nil {
 				// Check AWS033 covers this case.
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			tlsPolicyAttr := endpointBlock.GetAttribute("tls_security_policy")
 			if tlsPolicyAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with an outdated TLS policy (defaults to Policy-Min-TLS-1-0-2019-07).", block.FullName()),
 						endpointBlock.Range(),
 						scanner.SeverityError,
 					),
 				}
 
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if tlsPolicyAttr.Value().Equals(cty.StringVal("Policy-Min-TLS-1-0-2019-07")).True() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with an outdated TLS policy (set to Policy-Min-TLS-1-0-2019-07).", block.FullName()),
 						tlsPolicyAttr.Range(),
 						tlsPolicyAttr,
@@ -81,7 +81,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws035.go
+++ b/internal/app/tfsec/checks/aws035.go
@@ -48,7 +48,7 @@ func init() {
 			encryptionAttr := block.GetAttribute("at_rest_encryption_enabled")
 			if encryptionAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (missing at_rest_encryption_enabled attribute).", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -56,7 +56,7 @@ func init() {
 				}
 			} else if !isBooleanOrStringTrue(encryptionAttr) {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (at_rest_encryption_enabled set to false).", block.FullName()),
 						encryptionAttr.Range(),
 						encryptionAttr,
@@ -65,7 +65,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws036.go
+++ b/internal/app/tfsec/checks/aws036.go
@@ -48,7 +48,7 @@ func init() {
 			encryptionAttr := block.GetAttribute("transit_encryption_enabled")
 			if encryptionAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (missing transit_encryption_enabled attribute).", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -56,7 +56,7 @@ func init() {
 				}
 			} else if !isBooleanOrStringTrue(encryptionAttr) {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (transit_encryption_enabled set to false).", block.FullName()),
 						encryptionAttr.Range(),
 						encryptionAttr,
@@ -66,7 +66,7 @@ func init() {
 
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws037.go
+++ b/internal/app/tfsec/checks/aws037.go
@@ -54,7 +54,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if attr := block.GetAttribute("password_reuse_prevention"); attr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not have a password reuse prevention count set.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -64,7 +64,7 @@ func init() {
 				value, _ := attr.Value().AsBigFloat().Float64()
 				if value < 5 {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' has a password reuse count less than 5.", block.FullName()),
 							block.Range(),
 							scanner.SeverityWarning,
@@ -72,7 +72,7 @@ func init() {
 					}
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws038.go
+++ b/internal/app/tfsec/checks/aws038.go
@@ -53,7 +53,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if attr := block.GetAttribute("max_password_age"); attr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not have a max password age set.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -63,7 +63,7 @@ func init() {
 				value, _ := attr.Value().AsBigFloat().Float64()
 				if value > 90 {
 					return []scanner.Result{
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' has high password age.", block.FullName()),
 							attr.Range(),
 							attr,
@@ -72,7 +72,7 @@ func init() {
 					}
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws039.go
+++ b/internal/app/tfsec/checks/aws039.go
@@ -53,7 +53,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if attr := block.GetAttribute("minimum_password_length"); attr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not have a minimum password length set.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -63,7 +63,7 @@ func init() {
 				value, _ := attr.Value().AsBigFloat().Float64()
 				if value < 14 {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' has a minimum password length which is less than 14 characters.", block.FullName()),
 							block.Range(),
 							scanner.SeverityWarning,
@@ -71,7 +71,7 @@ func init() {
 					}
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws040.go
+++ b/internal/app/tfsec/checks/aws040.go
@@ -51,7 +51,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if attr := block.GetAttribute("require_symbols"); attr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not require a symbol in the password.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -60,7 +60,7 @@ func init() {
 			} else if attr.Value().Type() == cty.Bool {
 				if attr.Value().False() {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least one symbol in the password.", block.FullName()),
 							block.Range(),
 							scanner.SeverityWarning,
@@ -68,7 +68,7 @@ func init() {
 					}
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws041.go
+++ b/internal/app/tfsec/checks/aws041.go
@@ -51,7 +51,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if attr := block.GetAttribute("require_numbers"); attr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not require a number in the password.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -60,7 +60,7 @@ func init() {
 			} else if attr.Value().Type() == cty.Bool {
 				if attr.Value().False() {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least one number in the password.", block.FullName()),
 							block.Range(),
 							scanner.SeverityWarning,
@@ -68,7 +68,7 @@ func init() {
 					}
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws042.go
+++ b/internal/app/tfsec/checks/aws042.go
@@ -51,7 +51,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if attr := block.GetAttribute("require_lowercase_characters"); attr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not require a lowercase character in the password.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -60,7 +60,7 @@ func init() {
 			} else if attr.Value().Type() == cty.Bool {
 				if attr.Value().False() {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least lowercase character in the password.", block.FullName()),
 							block.Range(),
 							scanner.SeverityWarning,
@@ -68,7 +68,7 @@ func init() {
 					}
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws043.go
+++ b/internal/app/tfsec/checks/aws043.go
@@ -52,7 +52,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if attr := block.GetAttribute("require_uppercase_characters"); attr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not require an uppercase character in the password.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -61,7 +61,7 @@ func init() {
 			} else if attr.Value().Type() == cty.Bool {
 				if attr.Value().False() {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least one uppercase character in the password.", block.FullName()),
 							block.Range(),
 							scanner.SeverityWarning,
@@ -69,7 +69,7 @@ func init() {
 					}
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws044.go
+++ b/internal/app/tfsec/checks/aws044.go
@@ -44,7 +44,7 @@ func init() {
 
 			if accessKeyAttribute := block.GetAttribute("access_key"); accessKeyAttribute != nil && accessKeyAttribute.Type() == cty.String {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Provider '%s' has an access key specified.", block.FullName()),
 						accessKeyAttribute.Range(),
 						accessKeyAttribute,
@@ -53,7 +53,7 @@ func init() {
 				}
 			} else if secretKeyAttribute := block.GetAttribute("secret_key"); secretKeyAttribute != nil && secretKeyAttribute.Type() == cty.String {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Provider '%s' has a secret key specified.", block.FullName()),
 						secretKeyAttribute.Range(),
 						secretKeyAttribute,
@@ -62,7 +62,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws045.go
+++ b/internal/app/tfsec/checks/aws045.go
@@ -97,14 +97,14 @@ func init() {
 			wafAclIdBlock := block.GetAttribute("web_acl_id")
 			if wafAclIdBlock == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not have a WAF in front of it.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws046.go
+++ b/internal/app/tfsec/checks/aws046.go
@@ -68,7 +68,7 @@ func init() {
 						for _, actionValue := range actionValues {
 							if actionValue.AsString() == "*" {
 								return []scanner.Result{
-									check.NewResult(
+									check.NewFailingResult(
 										fmt.Sprintf("Resource '%s' has a wildcard action specified.", block.FullName()),
 										statementBlock.Range(),
 										scanner.SeverityError,
@@ -80,7 +80,7 @@ func init() {
 
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws047.go
+++ b/internal/app/tfsec/checks/aws047.go
@@ -3,8 +3,9 @@ package checks
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/zclconf/go-cty/cty"
 	"strings"
+
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
@@ -71,7 +72,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 
 			if block.GetAttribute("policy").Value().Type() != cty.String {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			rawJSON := []byte(block.GetAttribute("policy").Value().AsString())
@@ -86,7 +87,7 @@ func init() {
 				for _, statement := range policy.Statement {
 					if strings.ToLower(statement.Effect) == "allow" && (statement.Action == "*" || statement.Action == "sqs:*") {
 						return []scanner.Result{
-							check.NewResult(
+							check.NewFailingResult(
 								fmt.Sprintf("SQS policy '%s' has a wildcard action specified.", block.FullName()),
 								block.Range(),
 								scanner.SeverityError,
@@ -96,7 +97,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws048.go
+++ b/internal/app/tfsec/checks/aws048.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 	"github.com/zclconf/go-cty/cty"
@@ -48,7 +49,7 @@ func init() {
 
 			if efsEnabledAttr == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not specify if encryption should be used.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -56,7 +57,7 @@ func init() {
 				}
 			} else if efsEnabledAttr.Type() == cty.Bool && efsEnabledAttr.Value().False() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' actively does not have encryption applied.", block.FullName()),
 						efsEnabledAttr.Range(),
 						efsEnabledAttr,
@@ -64,9 +65,9 @@ func init() {
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws049.go
+++ b/internal/app/tfsec/checks/aws049.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 	"github.com/zclconf/go-cty/cty"
@@ -56,25 +57,25 @@ func init() {
 			protoAttr := block.GetAttribute("protocol")
 
 			if egressAttr.Type() == cty.Bool && egressAttr.Value().True() {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if actionAttr == nil || actionAttr.Type() != cty.String {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if actionAttr.Value().AsString() != "allow" {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if cidrBlockAttr := block.GetAttribute("cidr_block"); cidrBlockAttr != nil {
 
 				if isOpenCidr(cidrBlockAttr, check.Provider) {
 					if protoAttr.Value().AsString() == "all" || protoAttr.Value().AsString() == "-1" {
-						return nil
+						return []scanner.Result{check.NewPassingResult(block.Range())}
 					} else {
 						return []scanner.Result{
-							check.NewResult(
+							check.NewFailingResult(
 								fmt.Sprintf("Resource '%s' defines a Network ACL rule that allows specific ingress ports from anywhere.", block.FullName()),
 								cidrBlockAttr.Range(),
 								scanner.SeverityWarning,
@@ -89,10 +90,10 @@ func init() {
 
 				if isOpenCidr(ipv6CidrBlockAttr, check.Provider) {
 					if protoAttr.Value().AsString() == "all" || protoAttr.Value().AsString() == "-1" {
-						return nil
+						return []scanner.Result{check.NewPassingResult(block.Range())}
 					} else {
 						return []scanner.Result{
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf("Resource '%s' defines a Network ACL rule that allows specific ingress ports from anywhere.", block.FullName()),
 								ipv6CidrBlockAttr.Range(),
 								ipv6CidrBlockAttr,
@@ -104,7 +105,7 @@ func init() {
 
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws050.go
+++ b/internal/app/tfsec/checks/aws050.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 	"github.com/zclconf/go-cty/cty"
@@ -54,15 +55,15 @@ func init() {
 			protoAttr := block.GetAttribute("protocol")
 
 			if egressAttr.Type() == cty.Bool && egressAttr.Value().True() {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if actionAttr == nil || actionAttr.Type() != cty.String {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if actionAttr.Value().AsString() != "allow" {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if cidrBlockAttr := block.GetAttribute("cidr_block"); cidrBlockAttr != nil {
@@ -70,7 +71,7 @@ func init() {
 				if isOpenCidr(cidrBlockAttr, check.Provider) {
 					if protoAttr.Value().AsString() == "all" || protoAttr.Value().AsString() == "-1" {
 						return []scanner.Result{
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf("Resource '%s' defines a fully open ingress Network ACL rule with ALL ports open.", block.FullName()),
 								cidrBlockAttr.Range(),
 								cidrBlockAttr,
@@ -78,7 +79,7 @@ func init() {
 							),
 						}
 					} else {
-						return nil
+						return []scanner.Result{check.NewPassingResult(block.Range())}
 					}
 				}
 
@@ -89,7 +90,7 @@ func init() {
 				if isOpenCidr(ipv6CidrBlockAttr, check.Provider) {
 					if protoAttr.Value().AsString() == "all" || protoAttr.Value().AsString() == "-1" {
 						return []scanner.Result{
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf("Resource '%s' defines a fully open ingress Network ACL rule with ALL ports open.", block.FullName()),
 								ipv6CidrBlockAttr.Range(),
 								ipv6CidrBlockAttr,
@@ -97,13 +98,13 @@ func init() {
 							),
 						}
 					} else {
-						return nil
+						return []scanner.Result{check.NewPassingResult(block.Range())}
 					}
 				}
 
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws051.go
+++ b/internal/app/tfsec/checks/aws051.go
@@ -49,7 +49,7 @@ func init() {
 
 			if kmsKeyIdAttr == nil || kmsKeyIdAttr.Value().IsNull() {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a disabled RDS Cluster encryption.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -57,7 +57,7 @@ func init() {
 				}
 			} else if kmsKeyIdAttr.Equals("") {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' defines a disabled RDS Cluster encryption.", block.FullName()),
 						kmsKeyIdAttr.Range(),
 						kmsKeyIdAttr,
@@ -66,7 +66,7 @@ func init() {
 				}
 			} else if storageEncryptedattr == nil || storageEncryptedattr.IsFalse() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' defines a enabled RDS Cluster encryption but not the required encrypted_storage.", block.FullName()),
 						kmsKeyIdAttr.Range(),
 						kmsKeyIdAttr,
@@ -74,7 +74,7 @@ func init() {
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws052.go
+++ b/internal/app/tfsec/checks/aws052.go
@@ -45,7 +45,7 @@ func init() {
 
 			if block.MissingChild("storage_encrypted") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' has no storage encryption defined.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -56,15 +56,15 @@ func init() {
 			storageEncrypted := block.GetAttribute("storage_encrypted")
 			if storageEncrypted.IsFalse() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' has storage encrypted set to false", block.FullName()),
 						storageEncrypted.Range(),
 						storageEncrypted,
 						scanner.SeverityError,
-						),
+					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws053.go
+++ b/internal/app/tfsec/checks/aws053.go
@@ -49,17 +49,17 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 
 			if block.HasChild("performance_insights_enabled") && block.GetAttribute("performance_insights_enabled").IsTrue() {
-				if block.MissingChild("performance_insights_kms_key_id")  {
+				if block.MissingChild("performance_insights_kms_key_id") {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defines Performance Insights without encryption key specified.", block.FullName()),
 							block.Range(),
 							scanner.SeverityError,
 						),
 					}
-				} else if  block.GetAttribute("performance_insights_kms_key_id").IsEmpty() {
+				} else if block.GetAttribute("performance_insights_kms_key_id").IsEmpty() {
 					return []scanner.Result{
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' defines Performance Insights without encryption key specified.", block.FullName()),
 							block.GetAttribute("performance_insights_kms_key_id").Range(),
 							block.GetAttribute("performance_insights_kms_key_id"),
@@ -69,7 +69,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws054.go
+++ b/internal/app/tfsec/checks/aws054.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -59,7 +60,7 @@ func init() {
 				enforceHttps := endpointOptions.GetAttribute("enforce_https")
 				if enforceHttps != nil && enforceHttps.IsFalse() {
 					return []scanner.Result{
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Resource '%s' explicitly turns off enforcing https on the ElasticSearch domain.", block.FullName()),
 							enforceHttps.Range(),
 							enforceHttps,
@@ -69,7 +70,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws055.go
+++ b/internal/app/tfsec/checks/aws055.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -72,7 +73,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if block.MissingChild("node_to_node_encryption") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not configure node to node encryption on the domain.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -85,7 +86,7 @@ func init() {
 
 			if enabled == nil || enabled.IsFalse() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' explicitly disables node to node encryption on the domain.", block.FullName()),
 						enabled.Range(),
 						enabled,
@@ -94,7 +95,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws057.go
+++ b/internal/app/tfsec/checks/aws057.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -79,7 +80,7 @@ func init() {
 
 			if block.MissingChild("log_publishing_options") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not configure logging at rest on the domain.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -92,7 +93,7 @@ func init() {
 
 			if enabled != nil && enabled.IsFalse() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' explicitly disables logging on the domain.", block.FullName()),
 						enabled.Range(),
 						enabled,
@@ -101,7 +102,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws058.go
+++ b/internal/app/tfsec/checks/aws058.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -53,7 +54,7 @@ func init() {
 				if block.GetAttribute("principal").EndsWith("amazonaws.com") {
 					if block.MissingChild("source_arn") {
 						return []scanner.Result{
-							check.NewResult(
+							check.NewFailingResult(
 								fmt.Sprintf("Resource '%s' missing source ARN but has *.amazonaws.com Principal.", block.FullName()),
 								block.Range(),
 								scanner.SeverityError,
@@ -63,7 +64,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws059.go
+++ b/internal/app/tfsec/checks/aws059.go
@@ -89,13 +89,13 @@ func init() {
 					HasChild("result_configuration") {
 					block = block.GetBlock("configuration").GetBlock("result_configuration")
 				} else {
-					return nil
+					return []scanner.Result{check.NewPassingResult(block.Range())}
 				}
 			}
 
 			if block.MissingChild("encryption_configuration") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' missing encryption configuration block.", blockName),
 						block.Range(),
 						scanner.SeverityError,
@@ -103,7 +103,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws060.go
+++ b/internal/app/tfsec/checks/aws060.go
@@ -76,7 +76,7 @@ func init() {
 
 			if block.MissingChild("configuration") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' is missing the configuration block.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -88,7 +88,7 @@ func init() {
 			if configBlock.HasChild("enforce_workgroup_configuration") &&
 				configBlock.GetAttribute("enforce_workgroup_configuration").IsFalse() {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' has enforce_workgroup_configuration set to false.", block.FullName()),
 						configBlock.Range(),
 						scanner.SeverityError,
@@ -96,7 +96,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws061.go
+++ b/internal/app/tfsec/checks/aws061.go
@@ -67,7 +67,7 @@ func init() {
 
 			if block.MissingChild("access_log_settings") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' is missing access log settings block.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -75,7 +75,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws062.go
+++ b/internal/app/tfsec/checks/aws062.go
@@ -61,14 +61,14 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 
 			if block.MissingChild("user_data") {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			userData := block.GetAttribute("user_data")
 			if userData.Contains("AWS_ACCESS_KEY_ID", parser.IgnoreCase) &&
 				userData.RegexMatches("(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}") {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' has userdata with access key id defined.", block.FullName()),
 						userData.Range(),
 						userData,
@@ -80,7 +80,7 @@ func init() {
 			if userData.Contains("AWS_SECRET_ACCESS_KEY", parser.IgnoreCase) &&
 				userData.RegexMatches("(?i)aws_secre.+[=:]\\s{0,}[A-Za-z0-9\\/+=]{40}.?") {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' has userdata with access secret key defined.", block.FullName()),
 						userData.Range(),
 						userData,
@@ -88,7 +88,7 @@ func init() {
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws063.go
+++ b/internal/app/tfsec/checks/aws063.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -57,9 +58,9 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudtrail"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
-			if block.MissingChild("is_multi_region_trail")  {
+			if block.MissingChild("is_multi_region_trail") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not set multi region trail config.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -70,15 +71,15 @@ func init() {
 			multiRegion := block.GetAttribute("is_multi_region_trail")
 			if multiRegion.IsFalse() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' does not enable multi region trail.", block.FullName()),
 						multiRegion.Range(),
 						multiRegion,
 						scanner.SeverityWarning,
-						),
+					),
 				}
-			}/**/
-			return nil
+			} /**/
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws064.go
+++ b/internal/app/tfsec/checks/aws064.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -60,9 +61,9 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudtrail"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
-			if block.MissingChild("enable_log_file_validation")  {
+			if block.MissingChild("enable_log_file_validation") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not enable log file validation.", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
@@ -73,15 +74,15 @@ func init() {
 			logFileValidation := block.GetAttribute("enable_log_file_validation")
 			if logFileValidation.IsFalse() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' does not enable log file validation.", block.FullName()),
 						logFileValidation.Range(),
 						logFileValidation,
 						scanner.SeverityWarning,
 					),
 				}
-			}/**/
-			return nil
+			} /**/
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws065.go
+++ b/internal/app/tfsec/checks/aws065.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -61,30 +62,30 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudtrail"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
-				
+
 			if block.MissingChild("kms_key_id") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not have a kms_key_id set.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
-						),
+					),
 				}
 			}
 
 			kmsKeyId := block.GetAttribute("kms_key_id")
 			if kmsKeyId.IsEmpty() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' has a kms_key_id but it is not set.", block.FullName()),
 						kmsKeyId.Range(),
 						kmsKeyId,
 						scanner.SeverityError,
-						),
+					),
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws067.go
+++ b/internal/app/tfsec/checks/aws067.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -68,24 +69,24 @@ func init() {
 
 			if block.MissingChild("enabled_cluster_log_types") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' missing the enabled_cluster_log_types attribute to enable control plane logging", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
-						),
+					),
 				}
 			}
 
 			configuredLogging := block.GetAttribute("enabled_cluster_log_types")
 			var logTypeResults []scanner.Result
 			for _, logType := range controlPlaneLogging {
-				if ! configuredLogging.Contains(logType) {
-					logTypeResults = append(logTypeResults, check.NewResultWithValueAnnotation(
+				if !configuredLogging.Contains(logType) {
+					logTypeResults = append(logTypeResults, check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' is missing the control plane log type '%s'", block.FullName(), logType),
 						configuredLogging.Range(),
 						configuredLogging,
 						scanner.SeverityError,
-						))
+					))
 				}
 			}
 

--- a/internal/app/tfsec/checks/aws068.go
+++ b/internal/app/tfsec/checks/aws068.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -55,7 +56,7 @@ func init() {
 
 			if block.MissingChild("vpc_config") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' has no vpc_config block specified so default public access cidrs is set", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -66,7 +67,7 @@ func init() {
 			vpcConfig := block.GetBlock("vpc_config")
 			if vpcConfig.MissingChild("public_access_cidrs") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' is using default public access cidrs in the vpc config", block.FullName()),
 						vpcConfig.Range(),
 						scanner.SeverityError,
@@ -77,7 +78,7 @@ func init() {
 			publicAccessCidrs := vpcConfig.GetAttribute("public_access_cidrs")
 			if isOpenCidr(publicAccessCidrs, scanner.AWSProvider) {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' has public access cidr explicitly set to wide open", block.FullName()),
 						publicAccessCidrs.Range(),
 						publicAccessCidrs,
@@ -85,7 +86,7 @@ func init() {
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/aws069.go
+++ b/internal/app/tfsec/checks/aws069.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -55,7 +56,7 @@ func init() {
 
 			if block.MissingChild("vpc_config") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' has no vpc_config block specified so default public access is enabled", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -66,7 +67,7 @@ func init() {
 			vpcConfig := block.GetBlock("vpc_config")
 			if vpcConfig.MissingChild("endpoint_public_access") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' is using default public access in the vpc config", block.FullName()),
 						vpcConfig.Range(),
 						scanner.SeverityError,
@@ -77,7 +78,7 @@ func init() {
 			publicAccessEnabled := vpcConfig.GetAttribute("endpoint_public_access")
 			if publicAccessEnabled.IsTrue() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf("Resource '%s' has public access is explicitly set to enabled", block.FullName()),
 						publicAccessEnabled.Range(),
 						publicAccessEnabled,
@@ -85,7 +86,7 @@ func init() {
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu001.go
+++ b/internal/app/tfsec/checks/azu001.go
@@ -52,14 +52,14 @@ func init() {
 
 			directionAttr := block.GetAttribute("direction")
 			if directionAttr == nil || directionAttr.Type() != cty.String || directionAttr.Value().AsString() != "Inbound" {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if prefixAttr := block.GetAttribute("source_address_prefix"); prefixAttr != nil && prefixAttr.Type() == cty.String {
 				if isOpenCidr(prefixAttr, check.Provider) {
 					if accessAttr := block.GetAttribute("access"); accessAttr != nil && accessAttr.Value().AsString() == "Allow" {
 						return []scanner.Result{
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf(
 									"Resource '%s' defines a fully open %s network security group rule.",
 									block.FullName(),
@@ -80,7 +80,7 @@ func init() {
 				if isOpenCidr(prefixesAttr, check.Provider) {
 					if accessAttr := block.GetAttribute("access"); accessAttr != nil && accessAttr.Value().AsString() == "Allow" {
 						results = append(results,
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf("Resource '%s' defines a fully open security group rule.", block.FullName()),
 								prefixesAttr.Range(),
 								prefixesAttr,

--- a/internal/app/tfsec/checks/azu002.go
+++ b/internal/app/tfsec/checks/azu002.go
@@ -50,14 +50,14 @@ func init() {
 
 			directionAttr := block.GetAttribute("direction")
 			if directionAttr == nil || directionAttr.Type() != cty.String || directionAttr.Value().AsString() != "Outbound" {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if prefixAttr := block.GetAttribute("destination_address_prefix"); prefixAttr != nil && prefixAttr.Type() == cty.String {
 				if isOpenCidr(prefixAttr, check.Provider) {
 					if accessAttr := block.GetAttribute("access"); accessAttr != nil && accessAttr.Value().AsString() == "Allow" {
 						return []scanner.Result{
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf(
 									"Resource '%s' defines a fully open %s network security group rule.",
 									block.FullName(),
@@ -78,7 +78,7 @@ func init() {
 				if isOpenCidr(prefixesAttr, check.Provider) {
 					if accessAttr := block.GetAttribute("access"); accessAttr != nil && accessAttr.Value().AsString() == "Allow" {
 						results = append(results,
-							check.NewResultWithValueAnnotation(
+							check.NewFailingResultWithValueAnnotation(
 								fmt.Sprintf("Resource '%s' defines a fully open security group rule.", block.FullName()),
 								prefixesAttr.Range(),
 								prefixesAttr,

--- a/internal/app/tfsec/checks/azu003.go
+++ b/internal/app/tfsec/checks/azu003.go
@@ -50,7 +50,7 @@ func init() {
 			encryptionSettingsBlock := block.GetBlock("encryption_settings")
 			if encryptionSettingsBlock == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf(
 							"Resource '%s' defines an unencrypted managed disk.",
 							block.FullName(),
@@ -64,7 +64,7 @@ func init() {
 			enabledAttr := encryptionSettingsBlock.GetAttribute("enabled")
 			if enabledAttr != nil && enabledAttr.Type() == cty.Bool && enabledAttr.Value().False() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf(
 							"Resource '%s' defines an unencrypted managed disk.",
 							block.FullName(),
@@ -76,7 +76,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu004.go
+++ b/internal/app/tfsec/checks/azu004.go
@@ -46,7 +46,7 @@ func init() {
 			encryptionStateAttr := block.GetAttribute("encryption_state")
 			if encryptionStateAttr != nil && encryptionStateAttr.Type() == cty.String && encryptionStateAttr.Value().AsString() == "Disabled" {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf(
 							"Resource '%s' defines an unencrypted data lake store.",
 							block.FullName(),
@@ -58,7 +58,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu005.go
+++ b/internal/app/tfsec/checks/azu005.go
@@ -51,7 +51,7 @@ func init() {
 				passwordAuthDisabledAttr := linuxConfigBlock.GetAttribute("disable_password_authentication")
 				if passwordAuthDisabledAttr != nil && passwordAuthDisabledAttr.Type() == cty.Bool && passwordAuthDisabledAttr.Value().False() {
 					return []scanner.Result{
-						check.NewResultWithValueAnnotation(
+						check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf(
 								"Resource '%s' has password authentication enabled. Use SSH keys instead.",
 								block.FullName(),
@@ -64,7 +64,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu006.go
+++ b/internal/app/tfsec/checks/azu006.go
@@ -48,7 +48,7 @@ func init() {
 			if networkprofileBlock := block.GetBlock("network_profile"); networkprofileBlock != nil {
 				if networkprofileBlock.GetAttribute("network_policy") == nil {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf(
 								"Resource '%s' do not have network_policy define. network_policy should be defined to have opportunity allow or block traffic to pods",
 								block.FullName(),
@@ -60,7 +60,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu007.go
+++ b/internal/app/tfsec/checks/azu007.go
@@ -49,7 +49,7 @@ func init() {
 			rbacBlock := block.GetBlock("role_based_access_control")
 			if rbacBlock == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines without RBAC", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -60,7 +60,7 @@ func init() {
 			enabledAttr := rbacBlock.GetAttribute("enabled")
 			if enabledAttr.Type() == cty.Bool && enabledAttr.Value().False() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf(
 							"Resource '%s' RBAC disabled.",
 							block.FullName(),
@@ -72,7 +72,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu008.go
+++ b/internal/app/tfsec/checks/azu008.go
@@ -49,7 +49,7 @@ func init() {
 					block.GetAttribute("private_cluster_enabled").IsFalse()) {
 				{
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defined without limited set of IP address ranges to the API server.", block.FullName()),
 							block.Range(),
 							scanner.SeverityError,
@@ -57,7 +57,7 @@ func init() {
 					}
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu009.go
+++ b/internal/app/tfsec/checks/azu009.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 	"github.com/zclconf/go-cty/cty"
@@ -48,7 +49,7 @@ func init() {
 			addonprofileBlock := block.GetBlock("addon_profile")
 			if addonprofileBlock == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' AKS logging to Azure Monitoring is not configured (missing addon_profile).", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -59,7 +60,7 @@ func init() {
 			omsagentBlock := addonprofileBlock.GetBlock("oms_agent")
 			if omsagentBlock == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' AKS logging to Azure Monitoring is not configured (missing oms_agent).", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -68,9 +69,9 @@ func init() {
 			}
 
 			enabledAttr := omsagentBlock.GetAttribute("enabled")
-			if enabledAttr.Type() == cty.Bool && enabledAttr.Value().False() || enabledAttr == nil{
+			if enabledAttr.Type() == cty.Bool && enabledAttr.Value().False() || enabledAttr == nil {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf(
 							"Resource '%s' AKS logging to Azure Monitoring is not configured (oms_agent disabled).",
 							block.FullName(),
@@ -82,7 +83,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu010.go
+++ b/internal/app/tfsec/checks/azu010.go
@@ -45,7 +45,7 @@ func init() {
 			enabledAttr := block.GetAttribute("enable_https_traffic_only")
 			if enabledAttr != nil && enabledAttr.Type() == cty.Bool && enabledAttr.Value().False() {
 				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
+					check.NewFailingResultWithValueAnnotation(
 						fmt.Sprintf(
 							"Resource '%s' enable_https_traffic_only disabled.",
 							block.FullName(),
@@ -57,7 +57,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu011.go
+++ b/internal/app/tfsec/checks/azu011.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
@@ -61,7 +62,7 @@ func init() {
 					value := properties.MapValue("publicAccess")
 					if value == cty.StringVal("blob") || value == cty.StringVal("container") {
 						return []scanner.Result{
-							check.NewResult(
+							check.NewFailingResult(
 								fmt.Sprintf("Resource '%s' defines publicAccess as '%s', should be 'off .", block.FullName(), value),
 								block.Range(),
 								scanner.SeverityError,
@@ -71,7 +72,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu012.go
+++ b/internal/app/tfsec/checks/azu012.go
@@ -53,7 +53,7 @@ func init() {
 
 			if block.IsResourceType("azurerm_storage_account") {
 				if block.MissingChild("network_rules") {
-					return nil
+					return []scanner.Result{check.NewPassingResult(block.Range())}
 				}
 				block = block.GetBlock("network_rules")
 			}
@@ -61,7 +61,7 @@ func init() {
 			defaultAction := block.GetAttribute("default_action")
 			if defaultAction != nil && defaultAction.Equals("Allow", parser.IgnoreCase) {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a default_action of Allow. It should be Deny.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -69,7 +69,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu013.go
+++ b/internal/app/tfsec/checks/azu013.go
@@ -98,7 +98,7 @@ func init() {
 
 			if block.IsResourceType("azurerm_storage_account") {
 				if block.MissingChild("network_rules") {
-					return nil
+					return []scanner.Result{check.NewPassingResult(block.Range())}
 				}
 				block = block.GetBlock("network_rules")
 			}
@@ -107,7 +107,7 @@ func init() {
 				bypass := block.GetAttribute("bypass")
 				if !bypass.Contains("AzureServices") {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defines a network rule that doesn't allow bypass of Microsoft Services.", block.FullName()),
 							block.Range(),
 							scanner.SeverityError,
@@ -116,7 +116,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu014.go
+++ b/internal/app/tfsec/checks/azu014.go
@@ -57,7 +57,7 @@ func init() {
 
 			if block.HasChild("enable_https_traffic_only") && block.GetAttribute("enable_https_traffic_only").IsFalse() {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' explicitly turns off secure transfer to storage account.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -65,7 +65,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu015.go
+++ b/internal/app/tfsec/checks/azu015.go
@@ -52,14 +52,14 @@ func init() {
 
 			if block.MissingChild("min_tls_version") || block.GetAttribute("min_tls_version").IsNone("TLS1_2") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' should have the min tls version set to TLS1_2 .", block.FullName()),
 						block.Range(),
 						scanner.SeverityWarning,
 					),
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu016.go
+++ b/internal/app/tfsec/checks/azu016.go
@@ -68,7 +68,7 @@ func init() {
 				queueProps := block.GetBlock("queue_properties")
 				if queueProps.MissingChild("logging") {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defines a Queue Services storage account without Storage Analytics logging.", block.FullName()),
 							block.Range(),
 							scanner.SeverityWarning,
@@ -77,7 +77,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu017.go
+++ b/internal/app/tfsec/checks/azu017.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -92,13 +93,13 @@ func init() {
 
 			for _, rule := range securityRules {
 				if rule.HasChild("access") && rule.GetAttribute("access").Equals("Deny", parser.IgnoreCase) {
-					return nil
+					return []scanner.Result{check.NewPassingResult(block.Range())}
 				}
 				if rule.HasChild("destination_port_range") && rule.GetAttribute("destination_port_range").Contains("22") {
 					if rule.HasChild("source_address_prefix") {
 						if rule.GetAttribute("source_address_prefix").IsAny("*", "0.0.0.0", "/0", "internet", "any") {
 							return []scanner.Result{
-								check.NewResult(
+								check.NewFailingResult(
 									fmt.Sprintf("Resource '%s' has a .", block.FullName()),
 									block.Range(),
 									scanner.SeverityError,
@@ -108,7 +109,7 @@ func init() {
 					}
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu018.go
+++ b/internal/app/tfsec/checks/azu018.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -58,7 +59,7 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if block.MissingChild("extended_auditing_policy") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not have extended audit configured.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -66,7 +67,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/azu019.go
+++ b/internal/app/tfsec/checks/azu019.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -60,18 +61,18 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if !block.IsResourceType("azurerm_mssql_database_extended_auditing_policy") {
 				if block.MissingChild("extended_auditing_policy") {
-					return nil
+					return []scanner.Result{check.NewPassingResult(block.Range())}
 				}
 				block = block.GetBlock("extended_auditing_policy")
 			}
 
 			if block.MissingChild("retention_in_days") {
 				// using default of unlimited
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 			if block.GetAttribute("retention_in_days").LessThan(90) {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' specifies a retention period of less than 90 days.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -79,7 +80,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/gcp001.go
+++ b/internal/app/tfsec/checks/gcp001.go
@@ -58,7 +58,7 @@ func init() {
 			if keyBlock != nil {
 				if keyBlock.GetAttribute("raw_key") == nil && keyBlock.GetAttribute("kms_key_self_link") == nil {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defines an unencrypted disk. You should specify raw_key or kms_key_self_link.", block.FullName()),
 							keyBlock.Range(),
 							scanner.SeverityError,
@@ -67,7 +67,7 @@ func init() {
 
 				}
 			}
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/gcp003.go
+++ b/internal/app/tfsec/checks/gcp003.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
@@ -45,7 +46,7 @@ func init() {
 			if sourceRanges := block.GetAttribute("source_ranges"); sourceRanges != nil {
 				if isOpenCidr(sourceRanges, check.Provider) {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defines a fully open inbound firewall rule.", block.FullName()),
 							sourceRanges.Range(),
 							scanner.SeverityWarning,
@@ -54,7 +55,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 

--- a/internal/app/tfsec/checks/gcp004.go
+++ b/internal/app/tfsec/checks/gcp004.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -45,7 +46,7 @@ func init() {
 
 				if isOpenCidr(destinationRanges, check.Provider) {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("Resource '%s' defines a fully open outbound firewall rule.", block.FullName()),
 							destinationRanges.Range(),
 							scanner.SeverityWarning,
@@ -54,7 +55,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/gcp005.go
+++ b/internal/app/tfsec/checks/gcp005.go
@@ -51,7 +51,7 @@ func init() {
 			enable_legacy_abac := block.GetAttribute("enable_legacy_abac")
 			if enable_legacy_abac != nil && enable_legacy_abac.Value().Type() == cty.String && enable_legacy_abac.Value().AsString() == "true" {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a cluster with ABAC enabled. Disable and rely on RBAC instead. ", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -59,7 +59,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/gcp006.go
+++ b/internal/app/tfsec/checks/gcp006.go
@@ -59,7 +59,7 @@ func init() {
 			if nodeMetadata != nil && nodeMetadata.Type() == cty.String &&
 				(nodeMetadata.Value().AsString() == "EXPOSE" || nodeMetadata.Value().AsString() == "UNSPECIFIED") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a cluster with node metadata exposed. node_metadata set to EXPOSE or UNSPECIFIED disables metadata concealment. ", block.FullName()),
 						nodeMetadata.Range(),
 						scanner.SeverityError,
@@ -67,7 +67,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/gcp007.go
+++ b/internal/app/tfsec/checks/gcp007.go
@@ -56,7 +56,7 @@ func init() {
 			legacyMetadataAPI := block.GetBlock("metadata").GetAttribute("disable-legacy-endpoints")
 			if legacyMetadataAPI.Type() == cty.String && legacyMetadataAPI.Value().AsString() != "true" || legacyMetadataAPI.Type() == cty.Bool && legacyMetadataAPI.Value().False() {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a cluster with legacy metadata endpoints enabled.", block.FullName()),
 						legacyMetadataAPI.Range(),
 						scanner.SeverityError,
@@ -64,7 +64,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/gcp008.go
+++ b/internal/app/tfsec/checks/gcp008.go
@@ -64,7 +64,7 @@ func init() {
 			staticAuthPass := masterAuthBlock.GetAttribute("password")
 			if masterAuthBlock == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not disable basic auth with static passwords for client authentication. Disable this with a master_auth block container empty strings for user and password.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -72,7 +72,7 @@ func init() {
 				}
 			} else if staticAuthUser.Type() == cty.String && staticAuthUser.Value().AsString() != "" && staticAuthPass.Type() == cty.String && staticAuthPass.Value().AsString() != "" {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a cluster using basic auth with static passwords for client authentication. It is recommended to use OAuth or service accounts instead.", block.FullName()),
 						masterAuthBlock.Range(),
 						scanner.SeverityError,
@@ -82,7 +82,7 @@ func init() {
 			issueClientCert := masterAuthBlock.GetBlock("client_certificate_config").GetAttribute("issue_client_certificate")
 			if issueClientCert.Type() == cty.Bool && issueClientCert.Value().True() || issueClientCert.Type() == cty.String && issueClientCert.Value().AsString() == "true" {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a cluster using basic auth with client certificates for authentication. This cert has no permissions if RBAC is enabled and ABAC is disabled. It is recommended to use OAuth or service accounts instead.", block.FullName()),
 						issueClientCert.Range(),
 						scanner.SeverityError,
@@ -90,7 +90,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/gcp009.go
+++ b/internal/app/tfsec/checks/gcp009.go
@@ -55,7 +55,7 @@ func init() {
 			pspBlock := block.GetBlock("pod_security_policy_config")
 			if pspBlock == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a cluster with no Pod Security Policy config defined. It is recommended to define a PSP for your pods and enable PSP enforcement.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -66,7 +66,7 @@ func init() {
 			enforcePSP := pspBlock.GetAttribute("enabled")
 			if enforcePSP.Type() == cty.Bool && enforcePSP.Value().False() || enforcePSP.Type() == cty.String && enforcePSP.Value().AsString() != "true" {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a cluster with Pod Security Policy enforcement disabled. It is recommended to define a PSP for your pods and enable PSP enforcement.", block.FullName()),
 						enforcePSP.Range(),
 						scanner.SeverityError,
@@ -74,7 +74,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/gcp010.go
+++ b/internal/app/tfsec/checks/gcp010.go
@@ -49,7 +49,7 @@ func init() {
 
 			if enable_shielded_nodes == nil {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a cluster with shielded nodes disabled. Shielded GKE Nodes provide strong, verifiable node identity and integrity to increase the security of GKE nodes and should be enabled on all GKE clusters.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -59,7 +59,7 @@ func init() {
 
 			if enable_shielded_nodes.Type() == cty.Bool && enable_shielded_nodes.Value().False() || enable_shielded_nodes.Type() == cty.String && enable_shielded_nodes.Value().AsString() != "true" {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' defines a cluster with shielded nodes disabled. Shielded GKE Nodes provide strong, verifiable node identity and integrity to increase the security of GKE nodes and should be enabled on all GKE clusters.", block.FullName()),
 						enable_shielded_nodes.Range(),
 						scanner.SeverityError,
@@ -67,7 +67,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/gcp011.go
+++ b/internal/app/tfsec/checks/gcp011.go
@@ -100,7 +100,7 @@ func init() {
 			for _, identities := range members {
 				if identities.IsKnown() && identities.Type() == cty.String && strings.HasPrefix(identities.AsString(), "user:") {
 					return []scanner.Result{
-						check.NewResult(
+						check.NewFailingResult(
 							fmt.Sprintf("'%s' grants IAM to a user object. It is recommended to manage user permissions with groups.", block.FullName()),
 							attributes.Range(),
 							scanner.SeverityWarning,
@@ -109,7 +109,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/gcp012.go
+++ b/internal/app/tfsec/checks/gcp012.go
@@ -46,12 +46,12 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 
 			if strings.HasPrefix(block.Label(), "google_container_cluster") && block.GetAttribute("remove_default_node_pool").IsTrue() {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if !block.HasBlock("node_config") {
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not define the node config and does not override the default service account. It is recommended to use a minimally privileged service account to run your GKE cluster.", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
@@ -60,14 +60,14 @@ func init() {
 			}
 			displayBlock := block.GetBlock("node_config")
 			serviceAccount := displayBlock.GetAttribute("service_account")
-			
+
 			if serviceAccount == nil || serviceAccount.IsEmpty() {
 				if displayBlock == nil {
 					displayBlock = block
 				}
 
 				return []scanner.Result{
-					check.NewResult(
+					check.NewFailingResult(
 						fmt.Sprintf("Resource '%s' does not override the default service account. It is recommended to use a minimally privileged service account to run your GKE cluster.", block.FullName()),
 						displayBlock.Range(),
 						scanner.SeverityError,
@@ -75,7 +75,7 @@ func init() {
 				}
 			}
 
-			return nil
+			return []scanner.Result{check.NewPassingResult(block.Range())}
 		},
 	})
 }

--- a/internal/app/tfsec/checks/gen001.go
+++ b/internal/app/tfsec/checks/gen001.go
@@ -59,11 +59,11 @@ func init() {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 
 			if len(block.Labels()) == 0 {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			if !security.IsSensitiveAttribute(block.TypeLabel()) {
-				return nil
+				return []scanner.Result{check.NewPassingResult(block.Range())}
 			}
 
 			var results []scanner.Result
@@ -75,7 +75,7 @@ func init() {
 						continue
 					}
 					if val.AsString() != "" {
-						results = append(results, check.NewResultWithValueAnnotation(
+						results = append(results, check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Variable '%s' includes a potentially sensitive default value.", block.FullName()),
 							attribute.Range(),
 							attribute,

--- a/internal/app/tfsec/checks/gen002.go
+++ b/internal/app/tfsec/checks/gen002.go
@@ -61,7 +61,7 @@ func init() {
 			for _, attribute := range block.GetAttributes() {
 				if security.IsSensitiveAttribute(attribute.Name()) {
 					if attribute.Type() == cty.String && attribute.Value().AsString() != "" {
-						results = append(results, check.NewResultWithValueAnnotation(
+						results = append(results, check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Local '%s' includes a potentially sensitive value which is defined within the project.", block.FullName()),
 							attribute.Range(),
 							attribute,

--- a/internal/app/tfsec/checks/gen003.go
+++ b/internal/app/tfsec/checks/gen003.go
@@ -90,7 +90,7 @@ func init() {
 				}
 				if security.IsSensitiveAttribute(attribute.Name()) {
 					if attribute.Type() == cty.String && attribute.Value().AsString() != "" {
-						results = append(results, check.NewResultWithValueAnnotation(
+						results = append(results, check.NewFailingResultWithValueAnnotation(
 							fmt.Sprintf("Block '%s' includes a potentially sensitive attribute which is defined within the project.", block.FullName()),
 							attribute.Range(),
 							attribute,

--- a/internal/app/tfsec/custom/processing.go
+++ b/internal/app/tfsec/custom/processing.go
@@ -2,6 +2,7 @@ package custom
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
 )
@@ -9,7 +10,7 @@ import (
 var matchFunctions = map[CheckAction]func(*parser.Block, *MatchSpec) bool{
 	IsPresent: func(block *parser.Block, spec *MatchSpec) bool {
 		return block.HasChild(spec.Name) || spec.IgnoreUndefined
-},
+	},
 	NotPresent: func(block *parser.Block, spec *MatchSpec) bool { return !block.HasChild(spec.Name) },
 	IsEmpty: func(block *parser.Block, spec *MatchSpec) bool {
 		if block.MissingChild(spec.Name) {
@@ -123,14 +124,14 @@ func processFoundChecks(checks ChecksFile) {
 					matchSpec := customCheck.MatchSpec
 					if !evalMatchSpec(rootBlock, matchSpec, ctx) {
 						return []scanner.Result{
-							check.NewResult(
+							check.NewFailingResult(
 								fmt.Sprintf("Custom check failed for resource %s. %s", rootBlock.FullName(), customCheck.ErrorMessage),
 								rootBlock.Range(),
 								customCheck.Severity,
 							),
 						}
 					}
-					return nil
+					return []scanner.Result{check.NewPassingResult(rootBlock.Range())}
 				},
 			})
 		}(*customCheck)

--- a/internal/app/tfsec/formatters/formatter.go
+++ b/internal/app/tfsec/formatters/formatter.go
@@ -10,6 +10,7 @@ type FormatterOption int
 
 const (
 	ConciseOutput FormatterOption = iota
+	IncludePassed FormatterOption = iota
 )
 
 // Formatter formats scan results into a specific format

--- a/internal/app/tfsec/scanner/check.go
+++ b/internal/app/tfsec/scanner/check.go
@@ -121,8 +121,18 @@ func (check *Check) IsRequiredForBlock(block *parser.Block) bool {
 	return true
 }
 
-// NewResult creates a new Result, containing the given description and range
-func (check *Check) NewResult(description string, r parser.Range, severity Severity) Result {
+func (check *Check) NewPassingResult(r parser.Range) Result {
+	return Result{
+		RuleID:          check.Code,
+		RuleDescription: check.Documentation.Summary,
+		RuleProvider:    check.Provider,
+		Description:     string(check.Documentation.Summary),
+		Range:           r,
+		Passed:          true,
+	}
+}
+
+func (check *Check) NewFailingResult(description string, r parser.Range, severity Severity) Result {
 	return Result{
 		RuleID:          check.Code,
 		RuleDescription: check.Documentation.Summary,
@@ -130,13 +140,14 @@ func (check *Check) NewResult(description string, r parser.Range, severity Sever
 		Description:     description,
 		Range:           r,
 		Severity:        severity,
+		Passed:          false,
 	}
 }
 
-func (check *Check) NewResultWithValueAnnotation(description string, r parser.Range, attr *parser.Attribute, severity Severity) Result {
+func (check *Check) NewFailingResultWithValueAnnotation(description string, r parser.Range, attr *parser.Attribute, severity Severity) Result {
 
 	if attr == nil || attr.IsLiteral() {
-		return check.NewResult(description, r, severity)
+		return check.NewFailingResult(description, r, severity)
 	}
 
 	var raw interface{}
@@ -154,7 +165,7 @@ func (check *Check) NewResultWithValueAnnotation(description string, r parser.Ra
 		raw, _ = attr.Value().AsBigFloat().Float64()
 		typeStr = "number"
 	default:
-		return check.NewResult(description, r, severity)
+		return check.NewFailingResult(description, r, severity)
 	}
 
 	return Result{
@@ -165,5 +176,6 @@ func (check *Check) NewResultWithValueAnnotation(description string, r parser.Ra
 		Range:           r,
 		RangeAnnotation: fmt.Sprintf("[%s] %#v", typeStr, raw),
 		Severity:        severity,
+		Passed:          false,
 	}
 }

--- a/internal/app/tfsec/scanner/result.go
+++ b/internal/app/tfsec/scanner/result.go
@@ -15,6 +15,7 @@ type Result struct {
 	Description     string       `json:"description"`
 	RangeAnnotation string       `json:"-"`
 	Severity        Severity     `json:"severity"`
+	Passed          bool         `json:"passed"`
 }
 
 type Severity string

--- a/internal/app/tfsec/test/ignore_test.go
+++ b/internal/app/tfsec/test/ignore_test.go
@@ -30,7 +30,7 @@ func Test_IgnoreSpecific(t *testing.T) {
 		RequiredLabels: []string{"bad"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			return []scanner.Result{
-				check.NewResult("example problem", block.Range(), scanner.SeverityError),
+				check.NewFailingResult("example problem", block.Range(), scanner.SeverityError),
 			}
 		},
 	})
@@ -40,7 +40,7 @@ func Test_IgnoreSpecific(t *testing.T) {
 		RequiredLabels: []string{"bad"},
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			return []scanner.Result{
-				check.NewResult("example problem", block.Range(), scanner.SeverityError),
+				check.NewFailingResult("example problem", block.Range(), scanner.SeverityError),
 			}
 		},
 	})

--- a/internal/app/tfsec/test/setup_test.go
+++ b/internal/app/tfsec/test/setup_test.go
@@ -41,7 +41,7 @@ resource "problem" "x" {
 		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
 			if block.GetAttribute("bad") != nil {
 				return []scanner.Result{
-					check.NewResult("example problem", block.Range(), scanner.SeverityError),
+					check.NewFailingResult("example problem", block.Range(), scanner.SeverityError),
 				}
 			}
 


### PR DESCRIPTION
References #623 

This PR adds a boolean argument to `--include-passed` checks in the result output.  This adds a boolean property on the `Result` object that is set to `true`/`false` depending on whether the check has passed or not.  If the command line argument is set, the passed results will display in the result output.

Additionally, I've updated the default formatter to reflect proper colors (green) for passing checks.  I also added some additional metrics (Total, Passed, Failed Checks) to the statistics output when the flag is passed.  This **does** respect the existing `--concise-output` flag.

Example:

![image](https://user-images.githubusercontent.com/24511611/108918616-4a5e5480-75f7-11eb-89af-79e5d275a02f.png)

This is my first time tinkering with Go, so feel free to nitpick as you see fit. I'm open to feedback.