### PR TITLE
Add argument to include passed checks in the output

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -165,7 +165,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		debug.Log("Starting scanner...")
-		results := scanner.New().ScanWithOptions(blocks, mergeWithoutDuplicates(excludedChecksList, tfsecConfig.ExcludedChecks), includePassed)
+		results := scanner.New().Scan(blocks, mergeWithoutDuplicates(excludedChecksList, tfsecConfig.ExcludedChecks), getScannerOptions()...)
 		results = updateResultSeverity(results)
 		results = removeDuplicatesAndUnwanted(results)
 
@@ -232,6 +232,14 @@ func getFormatterOptions() []formatters.FormatterOption {
 	var options []formatters.FormatterOption
 	if conciseOutput {
 		options = append(options, formatters.ConciseOutput)
+	}
+	return options
+}
+
+func getScannerOptions() []scanner.ScannerOption {
+	var options []scanner.ScannerOption
+	if includePassed {
+		options = append(options, scanner.IncludePassed)
 	}
 	return options
 }

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/tfsec/tfsec/internal/app/tfsec/config"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/tfsec/tfsec/internal/app/tfsec/config"
 
 	"github.com/tfsec/tfsec/internal/app/tfsec/custom"
 
@@ -37,6 +38,7 @@ var tfsecConfig = &config.Config{}
 var conciseOutput = false
 var excludeDownloaded = false
 var detailedExitCode = false
+var includePassed = false
 
 func init() {
 	rootCmd.Flags().BoolVar(&disableColours, "no-colour", disableColours, "Disable coloured output")
@@ -53,6 +55,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&conciseOutput, "concise-output", conciseOutput, "Reduce the amount of output and no statistics")
 	rootCmd.Flags().BoolVar(&excludeDownloaded, "exclude-downloaded-modules", excludeDownloaded, "Remove results for downloaded modules in .terraform folder")
 	rootCmd.Flags().BoolVar(&detailedExitCode, "detailed-exit-code", detailedExitCode, "Produce more detailed exit status codes.")
+	rootCmd.Flags().BoolVar(&includePassed, "include-passed", includePassed, "Include passed checks in the result output")
 }
 
 func main() {
@@ -162,7 +165,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		debug.Log("Starting scanner...")
-		results := scanner.New().Scan(blocks, mergeWithoutDuplicates(excludedChecksList, tfsecConfig.ExcludedChecks))
+		results := scanner.New().ScanWithOptions(blocks, mergeWithoutDuplicates(excludedChecksList, tfsecConfig.ExcludedChecks), includePassed)
 		results = updateResultSeverity(results)
 		results = removeDuplicatesAndUnwanted(results)
 
@@ -183,7 +186,7 @@ var rootCmd = &cobra.Command{
 
 		// If all failed checks are of INFO severity, then produce a success
 		// exit code (0).
-		if allInfo(results)  {
+		if allInfo(results) {
 			os.Exit(0)
 		}
 

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -196,7 +196,7 @@ var rootCmd = &cobra.Command{
 
 func getDetailedExitCode(results []scanner.Result) int {
 	// If there are no failed checks, then produce a success exit code (0).
-	if len(results) == 0 {
+	if len(results) == 0 || len(results) == countPassedResults(results) {
 		return 0
 	}
 
@@ -263,7 +263,7 @@ func mergeWithoutDuplicates(left, right []string) []string {
 
 func allInfo(results []scanner.Result) bool {
 	for _, result := range results {
-		if result.Severity != scanner.SeverityInfo {
+		if result.Severity != scanner.SeverityInfo && !result.Passed {
 			return false
 		}
 	}
@@ -320,4 +320,16 @@ func loadConfigFile(configFilePath string) *config.Config {
 	}
 	debug.Log("loaded config file")
 	return config
+}
+
+func countPassedResults(results []scanner.Result) int {
+	passed := 0
+
+	for _, result := range results {
+		if result.Passed {
+			passed++
+		}
+	}
+
+	return passed
 }

--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -233,6 +233,9 @@ func getFormatterOptions() []formatters.FormatterOption {
 	if conciseOutput {
 		options = append(options, formatters.ConciseOutput)
 	}
+	if includePassed {
+		options = append(options, formatters.IncludePassed)
+	}
 	return options
 }
 

--- a/internal/app/tfsec/formatters/checkstyle.go
+++ b/internal/app/tfsec/formatters/checkstyle.go
@@ -32,6 +32,8 @@ func FormatCheckStyle(w io.Writer, results []scanner.Result, _ string, options .
 
 	files := make(map[string][]checkstyleResult)
 
+	// TODO - Handle if the --include-passed argument is passed.
+
 	for _, result := range results {
 		fileResults := append(
 			files[result.Range.Filename],

--- a/internal/app/tfsec/formatters/csv.go
+++ b/internal/app/tfsec/formatters/csv.go
@@ -12,7 +12,7 @@ import (
 func FormatCSV(w io.Writer, results []scanner.Result, _ string, options ...FormatterOption) error {
 
 	records := [][]string{
-		{"file", "start_line", "end_line", "rule_id", "severity", "description", "link"},
+		{"file", "start_line", "end_line", "rule_id", "severity", "description", "link", "passed"},
 	}
 
 	for _, result := range results {
@@ -24,6 +24,7 @@ func FormatCSV(w io.Writer, results []scanner.Result, _ string, options ...Forma
 			string(result.Severity),
 			result.Description,
 			result.Link,
+			strconv.FormatBool(result.Passed),
 		})
 	}
 

--- a/internal/app/tfsec/formatters/default.go
+++ b/internal/app/tfsec/formatters/default.go
@@ -19,8 +19,13 @@ func FormatDefault(_ io.Writer, results []scanner.Result, _ string, options ...F
 
 	showStatistics := true
 	showSuccessOutput := true
+	includePassedChecks := false
 
 	for _, option := range options {
+		if option == IncludePassed {
+			includePassedChecks = true
+		}
+
 		if option == ConciseOutput {
 			showStatistics = false
 			showSuccessOutput = false
@@ -28,7 +33,7 @@ func FormatDefault(_ io.Writer, results []scanner.Result, _ string, options ...F
 		}
 	}
 
-	if len(results) == 0 {
+	if len(results) == 0 || len(results) == countPassedResults(results) {
 		if showStatistics {
 			_ = tml.Printf("\n")
 			printStatistics()
@@ -41,17 +46,27 @@ func FormatDefault(_ io.Writer, results []scanner.Result, _ string, options ...F
 
 	var severity string
 
+	severityFormat := map[scanner.Severity]string{
+		scanner.SeverityInfo:    tml.Sprintf("<white>%s</white>", scanner.SeverityInfo),
+		scanner.SeverityWarning: tml.Sprintf("<yellow>%s</yellow>", scanner.SeverityWarning),
+		scanner.SeverityError:   tml.Sprintf("<red>%s</red>", scanner.SeverityError),
+		"":                      tml.Sprintf("<white>%s</white>", scanner.SeverityInfo),
+	}
+
 	fmt.Println("")
 	for i, result := range results {
-		terminal.PrintErrorf("<underline>Problem %d</underline>\n", i+1)
+		resultHeader := fmt.Sprintf("<underline>Check %d</underline>\n", i+1)
 
-		switch result.Severity {
-		case scanner.SeverityError:
-			severity = tml.Sprintf("<red>%s</red>", result.Severity)
-		case scanner.SeverityWarning:
-			severity = tml.Sprintf("<yellow>%s</yellow>", result.Severity)
-		default:
-			severity = tml.Sprintf("<white>%s</white>", result.Severity)
+		if includePassedChecks && result.Passed {
+			terminal.PrintSuccessf(resultHeader)
+		} else {
+			terminal.PrintErrorf(resultHeader)
+		}
+
+		if includePassedChecks && result.Passed {
+			severity = tml.Sprintf("<green>PASSED</green>")
+		} else {
+			severity = severityFormat[result.Severity]
 		}
 
 		_ = tml.Printf(`
@@ -68,7 +83,7 @@ func FormatDefault(_ io.Writer, results []scanner.Result, _ string, options ...F
 		printStatistics()
 	}
 
-	terminal.PrintErrorf("\n%d potential problems detected.\n\n", len(results))
+	terminal.PrintErrorf("\n%d potential problems detected.\n\n", len(results)-countPassedResults(results))
 
 	return nil
 
@@ -122,16 +137,31 @@ func highlightCode(result scanner.Result) {
 	for lineNo := start; lineNo <= end; lineNo++ {
 		_ = tml.Printf("  <blue>% 6d</blue> | ", lineNo)
 		if lineNo >= result.Range.StartLine && lineNo <= result.Range.EndLine {
-			if lineNo == result.Range.StartLine && result.RangeAnnotation != "" {
-				_ = tml.Printf("<bold><red>%s</red>    <blue>%s</blue></bold>\n", lines[lineNo], result.RangeAnnotation)
+			if result.Passed {
+				_ = tml.Printf("<bold><green>%s</green></bold>", lines[lineNo])
+			} else if lineNo == result.Range.StartLine && result.RangeAnnotation != "" {
+				_ = tml.Printf("<bold><red>%s</red>    <blue>%s</blue></bold>", lines[lineNo], result.RangeAnnotation)
 			} else {
-				_ = tml.Printf("<bold><red>%s</red></bold>\n", lines[lineNo])
+				_ = tml.Printf("<bold><red>%s</red></bold>", lines[lineNo])
 			}
 		} else {
-			_ = tml.Printf("<yellow>%s</yellow>\n", lines[lineNo])
+			_ = tml.Printf("<yellow>%s</yellow>", lines[lineNo])
 		}
+
+		fmt.Printf("\n")
 	}
 
 	fmt.Println("")
+}
 
+func countPassedResults(results []scanner.Result) int {
+	passed := 0
+
+	for _, result := range results {
+		if result.Passed {
+			passed++
+		}
+	}
+
+	return passed
 }

--- a/internal/app/tfsec/formatters/formatter.go
+++ b/internal/app/tfsec/formatters/formatter.go
@@ -10,6 +10,7 @@ type FormatterOption int
 
 const (
 	ConciseOutput FormatterOption = iota
+	IncludePassed FormatterOption = iota
 )
 
 // Formatter formats scan results into a specific format

--- a/internal/app/tfsec/formatters/junit.go
+++ b/internal/app/tfsec/formatters/junit.go
@@ -53,8 +53,7 @@ func FormatJUnit(w io.Writer, results []scanner.Result, _ string, options ...For
 				Classname: result.Range.Filename,
 				Name:      fmt.Sprintf("[%s][%s] - %s", result.RuleID, result.Severity, result.Description),
 				Time:      "0",
-				Failure:	buildFailure(result),
-				},
+				Failure:   buildFailure(result),
 			},
 		)
 	}
@@ -106,15 +105,16 @@ func highlightCodeJunit(result scanner.Result) string {
 	return output
 }
 
-func buildFailure(result scanner.Result) JUnitFailure {
-	if(result.Passed) {
-		return nil
-	} else {
-		return &JUnitFailure{
-			Message: result.Description,
-			Contents: fmt.Sprintf("%s\n%s\n%s",
-				result.Range.String(),
-				highlightCodeJunit(result),
-				result.Link),
+func buildFailure(result scanner.Result) *JUnitFailure {
+	if result.Passed {
+		return (&JUnitFailure{})
+	}
+
+	return &JUnitFailure{
+		Message: result.Description,
+		Contents: fmt.Sprintf("%s\n%s\n%s",
+			result.Range.String(),
+			highlightCodeJunit(result),
+			result.Link),
 	}
 }

--- a/internal/app/tfsec/formatters/junit.go
+++ b/internal/app/tfsec/formatters/junit.go
@@ -43,7 +43,7 @@ func FormatJUnit(w io.Writer, results []scanner.Result, _ string, options ...For
 
 	output := JUnitTestSuite{
 		Name:     "tfsec",
-		Failures: fmt.Sprintf("%d", len(results)),
+		Failures: fmt.Sprintf("%d", len(results)-countPassedResults(results)),
 		Tests:    fmt.Sprintf("%d", len(results)),
 	}
 
@@ -53,12 +53,7 @@ func FormatJUnit(w io.Writer, results []scanner.Result, _ string, options ...For
 				Classname: result.Range.Filename,
 				Name:      fmt.Sprintf("[%s][%s] - %s", result.RuleID, result.Severity, result.Description),
 				Time:      "0",
-				Failure: &JUnitFailure{
-					Message: result.Description,
-					Contents: fmt.Sprintf("%s\n%s\n%s",
-						result.Range.String(),
-						highlightCodeJunit(result),
-						result.Link),
+				Failure:	buildFailure(result),
 				},
 			},
 		)
@@ -109,4 +104,17 @@ func highlightCodeJunit(result scanner.Result) string {
 	}
 
 	return output
+}
+
+func buildFailure(result scanner.Result) JUnitFailure {
+	if(result.Passed) {
+		return nil
+	} else {
+		return &JUnitFailure{
+			Message: result.Description,
+			Contents: fmt.Sprintf("%s\n%s\n%s",
+				result.Range.String(),
+				highlightCodeJunit(result),
+				result.Link),
+	}
 }

--- a/internal/app/tfsec/formatters/junit.go
+++ b/internal/app/tfsec/formatters/junit.go
@@ -107,7 +107,7 @@ func highlightCodeJunit(result scanner.Result) string {
 
 func buildFailure(result scanner.Result) *JUnitFailure {
 	if result.Passed {
-		return (&JUnitFailure{})
+		return nil
 	}
 
 	return &JUnitFailure{

--- a/internal/app/tfsec/formatters/sarif.go
+++ b/internal/app/tfsec/formatters/sarif.go
@@ -17,6 +17,8 @@ func FormatSarif(w io.Writer, results []scanner.Result, baseDir string, options 
 
 	run := report.AddRun("tfsec", "https://tfsec.dev")
 
+	// TODO - Handle if the --include-passed argument is passed.
+
 	for _, result := range results {
 		rule := run.AddRule(string(result.RuleID)).
 			WithDescription(result.Description).

--- a/internal/app/tfsec/formatters/text.go
+++ b/internal/app/tfsec/formatters/text.go
@@ -11,24 +11,36 @@ import (
 
 func FormatText(_ io.Writer, results []scanner.Result, _ string, options ...FormatterOption) error {
 
-	if len(results) == 0 {
+	if len(results) == 0 || len(results) == countPassedResults(results) {
 		fmt.Print("\nNo problems detected!\n")
 		return nil
 	}
 
+	includePassedChecks := false
+
+	for _, option := range options {
+		if option == IncludePassed {
+			includePassedChecks = true
+		}
+	}
+
 	var severity string
 
-	fmt.Printf("\n%d potential problems detected:\n\n", len(results))
+	fmt.Printf("\n%d potential problems detected:\n\n", len(results)-countPassedResults(results))
 	for i, result := range results {
-		fmt.Printf("Problem %d\n", i+1)
+		fmt.Printf("Check %d\n", i+1)
 
-		switch result.Severity {
-		case scanner.SeverityError:
-			severity = fmt.Sprintf("%s", result.Severity)
-		case scanner.SeverityWarning:
-			severity = fmt.Sprintf("%s", result.Severity)
-		default:
-			severity = fmt.Sprintf("%s", result.Severity)
+		if includePassedChecks && result.Passed {
+			severity = "PASSED"
+		} else {
+			switch result.Severity {
+			case scanner.SeverityError:
+				severity = fmt.Sprintf("%s", result.Severity)
+			case scanner.SeverityWarning:
+				severity = fmt.Sprintf("%s", result.Severity)
+			default:
+				severity = fmt.Sprintf("%s", result.Severity)
+			}
 		}
 
 		fmt.Printf(`

--- a/internal/app/tfsec/scanner/check.go
+++ b/internal/app/tfsec/scanner/check.go
@@ -162,6 +162,12 @@ func (check *Check) NewResult(description string, r parser.Range, severity Sever
 	}
 }
 
+func (check *Check) NewPassingResult(r parser.Range) Result {
+	var res = check.NewResult(string(check.Documentation.Summary), r, SeverityInfo)
+	res.Passed = true
+	return res
+}
+
 func (check *Check) NewResultWithValueAnnotation(description string, r parser.Range, attr *parser.Attribute, severity Severity) Result {
 
 	if attr == nil || attr.IsLiteral() {

--- a/internal/app/tfsec/scanner/result.go
+++ b/internal/app/tfsec/scanner/result.go
@@ -15,6 +15,7 @@ type Result struct {
 	Description     string       `json:"description"`
 	RangeAnnotation string       `json:"-"`
 	Severity        Severity     `json:"severity"`
+	Passed          bool         `json:"passed"`
 }
 
 type Severity string

--- a/internal/app/tfsec/scanner/scanner.go
+++ b/internal/app/tfsec/scanner/scanner.go
@@ -35,6 +35,10 @@ func checkInList(code RuleCode, list []string) bool {
 
 // Scan takes all available hcl blocks and an optional context, and returns a slice of results. Each result indicates a potential security problem.
 func (scanner *Scanner) Scan(blocks []*parser.Block, excludedChecksList []string) []Result {
+	return scanner.ScanWithOptions(blocks, excludedChecksList, false)
+}
+
+func (scanner *Scanner) ScanWithOptions(blocks []*parser.Block, excludedChecksList []string, includePassed bool) []Result {
 
 	if len(blocks) == 0 {
 		return nil
@@ -47,12 +51,17 @@ func (scanner *Scanner) Scan(blocks []*parser.Block, excludedChecksList []string
 	checks := GetRegisteredChecks()
 	for _, block := range blocks {
 		for _, check := range checks {
-			func (check Check) {
+			func(check Check) {
 				if check.IsRequiredForBlock(block) {
 					debug.Log("Running check for %s on %s.%s (%s)...", check.Code, block.Type(), block.FullName(), block.Range().Filename)
-					for _, result := range check.Run(block, context) {
-						if !scanner.checkRangeIgnored(result.RuleID, result.Range) && !checkInList(result.RuleID, excludedChecksList) {
-							results = append(results, result)
+					var res = check.Run(block, context)
+					if includePassed && res == nil {
+						results = append(results, check.NewPassingResult(block.Range()))
+					} else {
+						for _, result := range res {
+							if !scanner.checkRangeIgnored(result.RuleID, result.Range) && !checkInList(result.RuleID, excludedChecksList) {
+								results = append(results, result)
+							}
 						}
 					}
 				}

--- a/internal/app/tfsec/scanner/scanner.go
+++ b/internal/app/tfsec/scanner/scanner.go
@@ -17,6 +17,12 @@ import (
 type Scanner struct {
 }
 
+type ScannerOption int
+
+const (
+	IncludePassed ScannerOption = iota
+)
+
 // New creates a new Scanner
 func New() *Scanner {
 	return &Scanner{}
@@ -33,12 +39,15 @@ func checkInList(code RuleCode, list []string) bool {
 	return false
 }
 
-// Scan takes all available hcl blocks and an optional context, and returns a slice of results. Each result indicates a potential security problem.
-func (scanner *Scanner) Scan(blocks []*parser.Block, excludedChecksList []string) []Result {
-	return scanner.ScanWithOptions(blocks, excludedChecksList, false)
-}
+func (scanner *Scanner) Scan(blocks []*parser.Block, excludedChecksList []string, options ...ScannerOption) []Result {
 
-func (scanner *Scanner) ScanWithOptions(blocks []*parser.Block, excludedChecksList []string, includePassed bool) []Result {
+	includePassed := false
+
+	for _, option := range options {
+		if option == IncludePassed {
+			includePassed = true
+		}
+	}
 
 	if len(blocks) == 0 {
 		return nil


### PR DESCRIPTION
References #623 

Based on feedback to the prior PR (#624), I've made this one less intrusive to the codebase. 

This PR adds an argument (`--include-passed`) that will include all checks that passed against the supplied Terraform.

I've added a `Passed` property on to the `Result` class so that it can be output via the different formatters.  This defaults to `false`.  Since the scanner already does the work of comparing the HCL blocks and checks to find the relevant ones, and then runs the actual check function against the block, I simply had to catch checks that _didn't fail_ their checkFunc (i.e. did not return a `result` object) if the flag was set.

By making the change here, we don't need to have additional conditional logic in each of the formatters or checks themselves to include/exclude results.  The checks will either be in the resulting range or not, depending on the flag.

**Other Notes**
- Followed the `FormatterOption` pattern to include options that can be passed in to the scanner.
- Updated the default and text formatters to change up some pretty-print when displaying passing checks.
- Updated the JUnit formatter to have the accurate count of Tests vs. Failures.
- Updated the CSV formatter to include a `passed` column.
- Returns the appropriate exit code based on the existing logic, even when there are passed results.