### PR TITLE
Add option to not search for tf files

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -37,6 +37,7 @@ var tfsecConfig = &config.Config{}
 var conciseOutput = false
 var excludeDownloaded = false
 var detailedExitCode = false
+var allDirs = false
 
 func init() {
 	rootCmd.Flags().BoolVar(&disableColours, "no-colour", disableColours, "Disable coloured output")
@@ -53,6 +54,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&conciseOutput, "concise-output", conciseOutput, "Reduce the amount of output and no statistics")
 	rootCmd.Flags().BoolVar(&excludeDownloaded, "exclude-downloaded-modules", excludeDownloaded, "Remove results for downloaded modules in .terraform folder")
 	rootCmd.Flags().BoolVar(&detailedExitCode, "detailed-exit-code", detailedExitCode, "Produce more detailed exit status codes.")
+	rootCmd.Flags().BoolVar(&allDirs, "force-all-dirs", allDirs, "Don't search for tf files, include everything below provided directory.")
 }
 
 func main() {
@@ -155,7 +157,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		debug.Log("Starting parser...")
-		blocks, err := parser.New(dir, tfvarsPath).ParseDirectory()
+		blocks, err := parser.New(dir, tfvarsPath, getParserOptions()...).ParseDirectory()
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -189,6 +191,14 @@ var rootCmd = &cobra.Command{
 
 		os.Exit(1)
 	},
+}
+
+func getParserOptions() []parser.ParserOption {
+	var opts []parser.ParserOption
+	if allDirs {
+		opts = append(opts, parser.DontSearchTfFiles)
+	}
+	return opts
 }
 
 func getDetailedExitCode(results []scanner.Result) int {

--- a/internal/app/tfsec/parser/parser.go
+++ b/internal/app/tfsec/parser/parser.go
@@ -10,18 +10,34 @@ import (
 	"path/filepath"
 )
 
+type ParserOption int
+
+const (
+	DontSearchTfFiles ParserOption = iota
+)
+
 // Parser is a tool for parsing terraform templates at a given file system location
 type Parser struct {
-	initialPath string
-	tfvarsPath  string
+	initialPath    string
+	tfvarsPath     string
+	lookForTfFiles bool
 }
 
 // New creates a new Parser
-func New(initialPath string, tfvarsPath string) *Parser {
-	return &Parser{
+func New(initialPath string, tfvarsPath string, options ...ParserOption) *Parser {
+	p := &Parser{
 		initialPath: initialPath,
 		tfvarsPath:  tfvarsPath,
+		lookForTfFiles: true,
 	}
+
+	for _, option := range options {
+		switch option {
+		case DontSearchTfFiles:
+			p.lookForTfFiles = false
+		}
+	}
+	return p
 }
 
 // ParseDirectory parses all terraform files within a given directory
@@ -66,7 +82,7 @@ func (parser *Parser) ParseDirectory() (Blocks, error) {
 	}
 
 	tfPath := parser.initialPath
-	if len(subdirectories) > 0 {
+	if len(subdirectories) > 0 && parser.lookForTfFiles {
 		tfPath = subdirectories[0]
 		debug.Log("Project root set to '%s'...", tfPath)
 	}


### PR DESCRIPTION
Default action is to search for the first sub directory with a tf file. #634 issue reports that this causes an issue when running from the root of a dir with multiple child locations.

Provide --force-all-dirs argument not search for first tf file and just use the initial folder

Resolves #634 