### PR TITLE
fix 642

### DIFF
--- a/internal/app/tfsec/parser/attribute.go
+++ b/internal/app/tfsec/parser/attribute.go
@@ -235,6 +235,8 @@ func (attr *Attribute) IsEmpty() bool {
 	}
 	if attr.Value().IsNull() {
 		switch t := attr.hclAttribute.Expr.(type) {
+		case *hclsyntax.FunctionCallExpr:
+			return false
 		case *hclsyntax.ScopeTraversalExpr:
 			return false
 		case *hclsyntax.ConditionalExpr:


### PR DESCRIPTION
- fix the is empty when a function call is being provided
Resolve #642  
