### PR TITLE
Add check for tfvars files and warn if not being used.

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -157,6 +157,8 @@ var rootCmd = &cobra.Command{
 				fmt.Println(err)
 				os.Exit(1)
 			}
+		} else if unusedTfvarsPresent(dir) {
+			tml.Printf("\n<yellow>Warning: A tfvars file was found but not automatically used. \nDid you mean to specify the --tf-vars flag?</yellow>\n")
 		}
 
 		debug.Log("Starting parser...")
@@ -342,4 +344,13 @@ func countPassedResults(results []scanner.Result) int {
 	}
 
 	return passed
+}
+
+func unusedTfvarsPresent(checkDir string) bool {
+	glob := fmt.Sprintf("%s/*.tfvars", checkDir)
+	debug.Log("checking for tfvars files using glob: %s", glob)
+	if matches, err := filepath.Glob(glob); err == nil && len(matches) > 0 {
+		return true
+	}
+	return false
 }

--- a/example/withVars/main.tf
+++ b/example/withVars/main.tf
@@ -1,0 +1,35 @@
+
+resource "aws_security_group_rule" "my-rule" {
+    type        = "ingress"
+    cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource "aws_alb_listener" "my-alb-listener"{
+    port     = "80"
+    protocol = "HTTP"
+}
+
+resource "aws_db_security_group" "my-group" {
+
+}
+
+resource "azurerm_managed_disk" "source" {
+    encryption_settings {
+        enabled = var.enableEncryption
+    }
+}
+
+resource "aws_api_gateway_domain_name" "missing_security_policy" {
+}
+
+resource "aws_api_gateway_domain_name" "empty_security_policy" {
+    security_policy = ""
+}
+
+resource "aws_api_gateway_domain_name" "outdated_security_policy" {
+    security_policy = "TLS_1_0"
+}
+
+resource "aws_api_gateway_domain_name" "valid_security_policy" {
+    security_policy = "TLS_1_2"
+}

--- a/example/withVars/terraform.tfvars
+++ b/example/withVars/terraform.tfvars
@@ -1,0 +1,1 @@
+enableEncryption = false


### PR DESCRIPTION
Closes #641, provide a warning when a tfvars is available but not being used by tfsec
