### PR TITLE
adding aws es domain no logging enabled scanner

### DIFF
--- a/internal/app/tfsec/checks/aws057.go
+++ b/internal/app/tfsec/checks/aws057.go
@@ -87,17 +87,18 @@ func init() {
 				}
 			}
 
-			logOptions := block.GetBlock("log_publishing_options")
-			enabled := logOptions.GetAttribute("enabled")
-
-			if enabled != nil && enabled.IsFalse() {
-				return []scanner.Result{
-					check.NewResultWithValueAnnotation(
-						fmt.Sprintf("Resource '%s' explicitly disables logging on the domain.", block.FullName()),
-						enabled.Range(),
-						enabled,
-						scanner.SeverityError,
-					),
+			logOptions := block.GetBlocks("log_publishing_options")
+			for _, logOption := range logOptions {
+				enabled := logOption.GetAttribute("enabled")
+				if enabled != nil && enabled.IsFalse() {
+					return []scanner.Result{
+						check.NewResultWithValueAnnotation(
+							fmt.Sprintf("Resource '%s' explicitly disables logging on the domain.", block.FullName()),
+							enabled.Range(),
+							enabled,
+							scanner.SeverityError,
+						),
+					}
 				}
 			}
 

--- a/internal/app/tfsec/checks/aws070.go
+++ b/internal/app/tfsec/checks/aws070.go
@@ -1,0 +1,61 @@
+package checks
+
+import (
+	"fmt"
+	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
+	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
+)
+
+const AWSESDomainLoggingEnabled scanner.RuleCode = "AWS070"
+const AWSESDomainLoggingEnabledDescription scanner.RuleSummary = "ES Domain should have the logging enabled"
+const AWSESDomainLoggingEnabledExplanation = `
+ES domain should have logging enabled by default.
+`
+const AWSESDomainLoggingEnabledBadExample = `
+resource "aws_elasticsearch_domain" "example" {
+  // other config
+  // no log_publishing_options
+}
+`
+const AWSESDomainLoggingEnabledGoodExample = `
+resource "aws_elasticsearch_domain" "example" {
+  // other config
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
+    log_type                 = "AUDIT_LOGS"
+  }
+}
+`
+
+func init() {
+	scanner.RegisterCheck(scanner.Check{
+		Code: AWSESDomainLoggingEnabled,
+		Documentation: scanner.CheckDocumentation{
+			Summary:     AWSESDomainLoggingEnabledDescription,
+			Explanation: AWSESDomainLoggingEnabledExplanation,
+			BadExample:  AWSESDomainLoggingEnabledBadExample,
+			GoodExample: AWSESDomainLoggingEnabledGoodExample,
+			Links: []string{
+				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#log_publishing_options",
+			},
+		},
+		Provider:       scanner.AWSProvider,
+		RequiredTypes:  []string{"resource"},
+		RequiredLabels: []string{"aws_elasticsearch_domain"},
+		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
+
+			if block.MissingChild("log_publishing_options") {
+				return []scanner.Result{
+					check.NewResult(
+						fmt.Sprintf("Resource '%s' has no log_publishing_options block specified so no loging is enabled", block.FullName()),
+						block.Range(),
+						scanner.SeverityError,
+					),
+				}
+			}
+
+			return nil
+		},
+	})
+}

--- a/internal/app/tfsec/checks/aws070.go
+++ b/internal/app/tfsec/checks/aws070.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
 	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
-	"strings"
 )
 
 const AWSESDomainLoggingEnabled scanner.RuleCode = "AWS070"
@@ -49,7 +48,7 @@ func init() {
 			if block.MissingChild("log_publishing_options") {
 				return []scanner.Result{
 					check.NewResult(
-						fmt.Sprintf("Resource '%s' has no log_publishing_options block specified, no loging is enabled", block.FullName()),
+						fmt.Sprintf("Resource '%s' has no log_publishing_options block specified, no logging is enabled", block.FullName()),
 						block.Range(),
 						scanner.SeverityError,
 					),
@@ -60,7 +59,7 @@ func init() {
 			if logPublishingOptions.MissingChild("log_type") {
 				return []scanner.Result{
 					check.NewResult(
-						fmt.Sprintf("Resource '%s' is missing log_type configuration, no loging is enabled", block.FullName()),
+						fmt.Sprintf("Resource '%s' is missing log_type configuration, no logging is enabled", block.FullName()),
 						logPublishingOptions.Range(),
 						scanner.SeverityError,
 					),
@@ -68,7 +67,7 @@ func init() {
 			}
 
 			logType := logPublishingOptions.GetAttribute("log_type")
-					if !strings.Contains(logType.Value().AsString(), "AUDIT_LOGS") {
+					if !logType.Equals("AUDIT_LOGS") {
 						return []scanner.Result{
 							check.NewResult(
 								fmt.Sprintf("Resource '%s' is missing 'AUDIT_LOGS` in `log_type` so audit log is not enabled", block.FullName()),

--- a/internal/app/tfsec/test/aws057_test.go
+++ b/internal/app/tfsec/test/aws057_test.go
@@ -72,6 +72,28 @@ resource "aws_elasticsearch_domain" "bad_example" {
 `,
 			mustExcludeResultCode: checks.AWSElasticSearchHasDomainLogging,
 		},
+		{
+			name: "check fails when one of the log options are present but disabled",
+			source: `
+resource "aws_elasticsearch_domain" "bad_example" {
+  domain_name           = "example"
+  elasticsearch_version = "1.5"
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
+    log_type                 = "INDEX_SLOW_LOGS"
+    enabled                  = true
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
+    log_type                 = "AUDIT_LOGS"
+    enabled                  = false
+  }
+}
+`,
+			mustIncludeResultCode: checks.AWSElasticSearchHasDomainLogging,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/app/tfsec/test/aws070_test.go
+++ b/internal/app/tfsec/test/aws070_test.go
@@ -1,0 +1,77 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/tfsec/tfsec/internal/app/tfsec/checks"
+	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
+)
+
+func Test_AWSAWSESDomainShouldHaveAuditLogEnabled(t *testing.T) {
+
+	var tests = []struct {
+		name                  string
+		source                string
+		mustIncludeResultCode scanner.RuleCode
+		mustExcludeResultCode scanner.RuleCode
+	}{
+		{
+			name: "Test if log_type is missing throw an error",
+			source: `
+resource "aws_elasticsearch_domain" "example" {
+  // other config
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
+  }
+}
+`,
+			mustIncludeResultCode: checks.AWSESDomainLoggingEnabled,
+		},
+		{
+			name: "Test if log_publishing_options missing throw an error",
+			source: `
+resource "aws_elasticsearch_domain" "example" {
+  // other config
+}
+`,
+			mustIncludeResultCode: checks.AWSESDomainLoggingEnabled,
+		},
+		{
+			name: "Test if log_type missing AUDIT_LOGS throw an error",
+			source: `
+resource "aws_elasticsearch_domain" "example" {
+  // other config
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
+    log_type                 = "SEARCH_SLOW_LOGS,ES_APPLICATION_LOGS"
+  }
+}
+`,
+			mustIncludeResultCode: checks.AWSESDomainLoggingEnabled,
+		},
+		{
+			name: "Test check passes if conditions are met",
+			source: `
+resource "aws_elasticsearch_domain" "example" {
+  // other config
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
+    log_type                 = "AUDIT_LOGS"
+  }
+}
+`,
+			mustExcludeResultCode: checks.AWSESDomainLoggingEnabled,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := scanSource(test.source)
+			assertCheckCode(t, test.mustIncludeResultCode, test.mustExcludeResultCode, results)
+		})
+	}
+
+}

--- a/internal/app/tfsec/test/aws070_test.go
+++ b/internal/app/tfsec/test/aws070_test.go
@@ -45,7 +45,7 @@ resource "aws_elasticsearch_domain" "example" {
 
   log_publishing_options {
     cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
-    log_type                 = "SEARCH_SLOW_LOGS,ES_APPLICATION_LOGS"
+    log_type                 = "SLOW_LOGS"
   }
 }
 `,

--- a/internal/app/tfsec/test/aws070_test.go
+++ b/internal/app/tfsec/test/aws070_test.go
@@ -16,29 +16,7 @@ func Test_AWSAWSESDomainShouldHaveAuditLogEnabled(t *testing.T) {
 		mustExcludeResultCode scanner.RuleCode
 	}{
 		{
-			name: "Test if log_type is missing throw an error",
-			source: `
-resource "aws_elasticsearch_domain" "example" {
-  // other config
-
-  log_publishing_options {
-    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
-  }
-}
-`,
-			mustIncludeResultCode: checks.AWSESDomainLoggingEnabled,
-		},
-		{
-			name: "Test if log_publishing_options missing throw an error",
-			source: `
-resource "aws_elasticsearch_domain" "example" {
-  // other config
-}
-`,
-			mustIncludeResultCode: checks.AWSESDomainLoggingEnabled,
-		},
-		{
-			name: "Test if log_type missing AUDIT_LOGS throw an error",
+			name: "check fails if any of the log options dont specify log_type of AUDIT_LOGS",
 			source: `
 resource "aws_elasticsearch_domain" "example" {
   // other config
@@ -47,15 +25,25 @@ resource "aws_elasticsearch_domain" "example" {
     cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
     log_type                 = "SLOW_LOGS"
   }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
+    log_type                 = "TEST_LOGS"
+  }
 }
 `,
 			mustIncludeResultCode: checks.AWSESDomainLoggingEnabled,
 		},
 		{
-			name: "Test check passes if conditions are met",
+			name: "check passes if one of the log_type is AUDIT_LOGS and audit log is enabled",
 			source: `
 resource "aws_elasticsearch_domain" "example" {
   // other config
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
+    log_type                 = "SLOW_LOGS"
+  }
 
   log_publishing_options {
     cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn


### PR DESCRIPTION
`AWS057` checks if `log_publishing_options` is configured or not which closes  https://github.com/tfsec/tfsec/issues/331

### Changed `AWS057` to check all the `log_publishing_options`
There can be many `log_publishing_options` blocks so we need to check them all.

### New check `AWS070` - `AUDIT_LOGS`
Checks if any of the `log_publishing_options` has `AUDIT_LOGS`  enabled closes https://github.com/tfsec/tfsec/issues/412

Questions:
- should `AUDIT_LOGS` be a `warning` or `error`?
- should we extend `AWS057` with `AUDIT_LOGS` check?
   - this would prevent someone from ignoring only `AUDIT_LOGS` as `tfsec:ignore:AWS057` would ignore both lack of `logs` enabled and `AUDIT_LOGS` missing
