### PR TITLE
add basic support for aliases in ignore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Key attributes requested;
 
 - Provider: Select the provider from the list
 - Short Code: This is a very terse description of the check, it will form the check name
+- Alias: This is a alias that can be used in `tfsec:ignore` (aws-security-group-description-missing)
 - Summary: A slightly longer free text summary of the check
 - Required Types: What kind of blocks is this check for (resource, data, variable etc). Provide this as a space separated list
 - Required Label: What kind of labels is this check for (aws_instance, google_container_cluster). Provide this as a space separated list
@@ -33,6 +34,9 @@ Here's an example:
 ```go
 // The rule code for your check
 const AWSGibsonHackableCode scanner.RuleCode = "AWS123"
+
+// The alias for your check
+const AWSGibsonHackableAlias scanner.RuleAlias = "aws-gibson-hackable"
 
 // A description for your check - this message will be output to a user when the check fails.
 const AWSGibsonHackableDescription scanner.RuleSummary = "The Gibson should not be hackable"
@@ -65,8 +69,10 @@ func init() {
     
         	// our new check code
 		Code: AWSGibsonHackableCode,
-    
-        	// all of our documentation data that will be available in the output and/or at https://tfsec.dev/
+			// our alias for the check
+		Alias: AWSGibsonHackableAlias,	
+
+			// all of our documentation data that will be available in the output and/or at https://tfsec.dev/
 		Documentation: scanner.CheckDocumentation{
 			Summary:     AWSGibsonHackableDescription,
 			Explanation: AWSGibsonHackableExplanation,

--- a/cmd/tfsec-docs/webpage.go
+++ b/cmd/tfsec-docs/webpage.go
@@ -31,6 +31,10 @@ parent: {{$.Provider | ToUpperProvider }} Checks
 
 ## {{$.Documentation.Summary}}
 
+{{if $.Alias}}
+Alias: {{ $.Alias }}
+{{end}}
+
 ### Explanation
 
 {{$.Documentation.Explanation}}

--- a/cmd/tfsec-skeleton/checkGen.go
+++ b/cmd/tfsec-skeleton/checkGen.go
@@ -17,6 +17,7 @@ type checkSkeleton struct {
 	CheckName        string
 	ShortCode        string
 	Code             string
+	Alias            string
 	Summary          string
 	RequiredTypes    string
 	RequiredLabels   string
@@ -26,6 +27,7 @@ type checkSkeleton struct {
 
 var funcMap = template.FuncMap{
 	"ToUpper": strings.ToUpper,
+	"ToLower": strings.ToLower,
 }
 
 func generateCheckBody() error {
@@ -80,8 +82,9 @@ func constructSkeleton() (*checkSkeleton, error) {
 	summary := prompt.EnterInput("Enter very slightly longer summary: ")
 	blockTypes := prompt.EnterInput("Enter the supported block types: ")
 	blockLabels := prompt.EnterInput("Enter the supported block labels: ")
+	alias := prompt.EnterInput("Enter alias for this check e.g. (aws-security-group-description-missing): ")
 
-	checkBody, skeleton, err2 := populateSkeleton(summary, selected, shortCodeContent, blockTypes, blockLabels, err)
+	checkBody, skeleton, err2 := populateSkeleton(summary, selected, shortCodeContent, blockTypes, blockLabels, alias, err)
 	if err2 != nil {
 		return skeleton, err2
 	}
@@ -89,7 +92,7 @@ func constructSkeleton() (*checkSkeleton, error) {
 	return checkBody, nil
 }
 
-func populateSkeleton(summary string, selected string, shortCodeContent string, blockTypes string, blockLabels string, err error) (*checkSkeleton, *checkSkeleton, error) {
+func populateSkeleton(summary string, selected string, shortCodeContent string, blockTypes string, blockLabels string, alias string, err error) (*checkSkeleton, *checkSkeleton, error) {
 	checkBody := &checkSkeleton{}
 
 	checkBody.Summary = summary
@@ -99,6 +102,8 @@ func populateSkeleton(summary string, selected string, shortCodeContent string, 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	checkBody.Alias = alias
 
 	checkBody.CheckName = fmt.Sprintf("%s%s", strings.ToUpper(checkBody.Provider), strings.ReplaceAll(strings.Title(shortCodeContent), " ", ""))
 	checkBody.RequiredTypes = fmt.Sprintf("{\"%s\"}", strings.Join(strings.Split(blockTypes, " "), "\", \""))

--- a/cmd/tfsec-skeleton/checkGen.go
+++ b/cmd/tfsec-skeleton/checkGen.go
@@ -80,8 +80,8 @@ func constructSkeleton() (*checkSkeleton, error) {
 	}
 	shortCodeContent := prompt.EnterInput("Enter very terse description: ")
 	summary := prompt.EnterInput("Enter very slightly longer summary: ")
-	blockTypes := prompt.EnterInput("Enter the supported block types: ")
-	blockLabels := prompt.EnterInput("Enter the supported block labels: ")
+	blockTypes := prompt.EnterInput("Enter the supported block types e.g. (resource, data) : ")
+	blockLabels := prompt.EnterInput("Enter the supported block labels e.g. (aws_security_group): ")
 	alias := prompt.EnterInput("Enter alias for this check e.g. (aws-security-group-description-missing): ")
 
 	checkBody, skeleton, err2 := populateSkeleton(summary, selected, shortCodeContent, blockTypes, blockLabels, alias, err)

--- a/cmd/tfsec-skeleton/templates.go
+++ b/cmd/tfsec-skeleton/templates.go
@@ -8,6 +8,7 @@ import (
 )
 
 const {{.CheckName}} scanner.RuleCode = "{{.Provider | ToUpper }}{{ .Code}}"
+const {{.CheckName}}Alias scanner.RuleAlias = "{{.Alias | ToLower }}"
 const {{.CheckName}}Description scanner.RuleSummary = "{{.Summary}}"
 const {{.CheckName}}Explanation = ` + "`" + `
 
@@ -26,6 +27,7 @@ resource "" "good_example" {
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: {{.CheckName}},
+		Alias: {{.CheckName}}Alias,
 		Documentation: scanner.CheckDocumentation{
 			Summary:     {{.CheckName}}Description,
 			Explanation: {{.CheckName}}Explanation,

--- a/internal/app/tfsec/checks/aws018.go
+++ b/internal/app/tfsec/checks/aws018.go
@@ -10,6 +10,7 @@ import (
 
 // AWSNoDescriptionInSecurityGroup See https://github.com/tfsec/tfsec#included-checks for check info
 const AWSNoDescriptionInSecurityGroup scanner.RuleCode = "AWS018"
+const AWSNoDescriptionInSecurityGroupAlias scanner.RuleAlias= "aws-security-group-description-missing"
 const AWSNoDescriptionInSecurityGroupDescription scanner.RuleSummary = "Missing description for security group/security group rule."
 const AWSNoDescriptionInSecurityGroupExplanation = `
 Security groups and security group rules should include a description for auditing purposes.
@@ -47,6 +48,7 @@ resource "aws_security_group" "http" {
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSNoDescriptionInSecurityGroup,
+		Alias: AWSNoDescriptionInSecurityGroupAlias,
 		Documentation: scanner.CheckDocumentation{
 			Summary:     AWSNoDescriptionInSecurityGroupDescription,
 			Explanation: AWSNoDescriptionInSecurityGroupExplanation,

--- a/internal/app/tfsec/checks/aws060.go
+++ b/internal/app/tfsec/checks/aws060.go
@@ -8,6 +8,7 @@ import (
 )
 
 const AWSAthenaWorkgroupEnforceConfiguration scanner.RuleCode = "AWS060"
+const AWSAthenaWorkgroupEnforceConfigurationAlias scanner.RuleAlias= "aws-athena-configuration-missing"
 const AWSAthenaWorkgroupEnforceConfigurationDescription scanner.RuleSummary = "Athena workgroups should enforce configuration to prevent client disabling encryption"
 const AWSAthenaWorkgroupEnforceConfigurationExplanation = `
 Athena workgroup configuration should be enforced to prevent client side changes to disable encryption settings.
@@ -59,6 +60,7 @@ resource "aws_athena_workgroup" "good_example" {
 func init() {
 	scanner.RegisterCheck(scanner.Check{
 		Code: AWSAthenaWorkgroupEnforceConfiguration,
+		Alias: AWSAthenaWorkgroupEnforceConfigurationAlias,
 		Documentation: scanner.CheckDocumentation{
 			Summary:     AWSAthenaWorkgroupEnforceConfigurationDescription,
 			Explanation: AWSAthenaWorkgroupEnforceConfigurationExplanation,

--- a/internal/app/tfsec/scanner/check.go
+++ b/internal/app/tfsec/scanner/check.go
@@ -15,6 +15,9 @@ import (
 // RuleCode is a unique identifier for a check
 type RuleCode string
 
+// RuleAlias is a alias for a check
+type RuleAlias string
+
 // RuleSummary is a summary description for a check
 type RuleSummary string
 
@@ -36,6 +39,7 @@ func RuleProviderToString(provider RuleProvider) string {
 // "resource", and the labels to run on e.g. "aws_s3_bucket".
 type Check struct {
 	Code           RuleCode
+	Alias          RuleAlias
 	Documentation  CheckDocumentation
 	Provider       RuleProvider
 	RequiredTypes  []string
@@ -154,6 +158,7 @@ func wildcardMatch(pattern string, subject string) bool {
 func (check *Check) NewResult(description string, r parser.Range, severity Severity) Result {
 	return Result{
 		RuleID:          check.Code,
+		RuleAlias:       check.Alias,
 		RuleDescription: check.Documentation.Summary,
 		RuleProvider:    check.Provider,
 		Description:     description,
@@ -194,6 +199,7 @@ func (check *Check) NewResultWithValueAnnotation(description string, r parser.Ra
 
 	return Result{
 		RuleID:          check.Code,
+		RuleAlias:       check.Alias,
 		RuleDescription: check.Documentation.Summary,
 		RuleProvider:    check.Provider,
 		Description:     description,

--- a/internal/app/tfsec/scanner/result.go
+++ b/internal/app/tfsec/scanner/result.go
@@ -8,6 +8,7 @@ import (
 // by, a human-readable description and a range
 type Result struct {
 	RuleID          RuleCode     `json:"rule_id"`
+	RuleAlias       RuleAlias    `json:"rule_alias"`
 	RuleDescription RuleSummary  `json:"rule_description"`
 	RuleProvider    RuleProvider `json:"rule_provider"`
 	Link            string       `json:"link"`


### PR DESCRIPTION
closes #91

### Add Support for aliases in `tfsec:ignore`

Example:
Will ignore `AWS018` using `alias` instead of `tfsec:ignore:AWS018` 
```
resource "aws_security_group" "http" {
  name        = "http"

  //tfsec:ignore:aws-security-group-description-missing

  ingress {
    description = "HTTP from VPC"
    from_port   = 80
    to_port     = 80
    protocol    = "tcp"
    cidr_blocks = [aws_vpc.main.cidr_block]
  }
}
```

- Supports backward compatibility, checks without aliases are ignored. To do that: refactored the `scanner` to loop through a list of checks. Alias ignore for check is only added to the list if `Alias` is set for a check.
- Will emit alias to auto generated documentation if set
- Alias added as an option in `tfsec-skeleton`
- Updated `CONTRIBUTING.md` to mention Alias in examples

 ### Done:
- [x] alias support
- [x] documentation update
- [x] make check generator update
- [x] unit tests
- [x] backward compatibility for checks without alias

### TODO (when solution roughly accepted)
- [ ] add in more aliases
- [ ] more benchmarks + maybe some optimizations


### Benchmarks
for 6144 blocks the diff in running checks is
- no alias 8.26s 
- alias 8.76s

for 12288 blocks the diff in running checks is
- no alias 38s 
- alias 40s