### PR TITLE
Added test case for AWS004 check by including the aws_lb_listener

### DIFF
--- a/internal/app/tfsec/test/aws004_test.go
+++ b/internal/app/tfsec/test/aws004_test.go
@@ -24,6 +24,14 @@ resource "aws_alb_listener" "my-listener" {
 			mustIncludeResultCode: checks.AWSPlainHTTP,
 		},
 		{
+			name: "check aws_lb_listener using plain HTTP",
+			source: `
+resource "aws_lb_listener" "my-listener" {
+	protocol = "HTTP"
+}`,
+			mustIncludeResultCode: checks.AWSPlainHTTP,
+		},
+		{
 			name: "check aws_alb_listener using plain HTTP (via non specification)",
 			source: `
 resource "aws_alb_listener" "my-listener" {


### PR DESCRIPTION
I started working on #171 but it turned out it is already covered by older #12 
I noticed the test cases does not validate whether this check is executed against `aws_lb_listener` as well so I added it

The solution to #12 covers #171 and #243 as well