### PR TITLE
Fix publish-docs to update document

### DIFF
--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -12,22 +12,11 @@ function clone_site {
 
 function deploy {
 	echo "deploying changes"
-
-	if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-	    echo "except don't publish site for pull requests"
-	    exit 0
-	fi
-
-	if [[ "$TRAVIS_BRANCH" != "master" ]]; then
-	    echo "except we should only publish the master branch. stopping here"
-	    exit 0
-	fi
-
 	pushd _site
-	git config user.name "Travis Build"
-  git config user.email travis@tfsec
+	git config user.name "GitHub Actions Build"
+  git config user.email github-actions@tfsec
 	git add -A
-	git commit -m "Travis Build: ${TRAVIS_BUILD_NUMBER}. ${MESSAGE}" || true
+	git commit -m "GitHub Actions Build: ${GITHUB_RUN_ID}. ${MESSAGE}" || true
 	git push "${DEPLOY_REPO}" main:main || true
 	popd
 }

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -14,7 +14,7 @@ function deploy {
 	echo "deploying changes"
 	pushd _site
 	git config user.name "GitHub Actions Build"
-  git config user.email github-actions@tfsec
+	git config user.email github-actions@tfsec
 	git add -A
 	git commit -m "GitHub Actions Build: ${GITHUB_RUN_ID}. ${MESSAGE}" || true
 	git push "${DEPLOY_REPO}" main:main || true


### PR DESCRIPTION
The document https://tfsec.dev/docs/aws/AWS077/ isn't found.

![image](https://user-images.githubusercontent.com/13323303/113148460-d0ac2d00-926c-11eb-85f8-68a1fda49f22.png)

In the build `releasing tfsec`, the document was built but wasn't published.

https://github.com/tfsec/tfsec/runs/2236221933#step:8:129

```
+ echo 'deploying changes'
deploying changes
except don't publish site for pull requests
+ [[ '' != \f\a\l\s\e ]]
+ echo 'except don'\''t publish site for pull requests'
```

https://github.com/tfsec/tfsec/blob/107c86d3c686a3f37b548ef7d704c81cbcd0c0cb/scripts/publish-docs.sh#L16-L19

In #660 , CI was migrated from Travis to GitHub Actions, so we should fix the environment variables of Travis.
`make publish-docs` is run only in GitHub Action's `releasing tfsec`, and this build is run only when tag is pushed.
So we don't have to check the current branch in `make publish-docs`.