### PR TITLE
new flag include ignored and counting ignored checks

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -39,6 +39,7 @@ var conciseOutput = false
 var excludeDownloaded = false
 var detailedExitCode = false
 var includePassed = false
+var includeIgnored = false
 var allDirs = false
 
 func init() {
@@ -57,6 +58,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&excludeDownloaded, "exclude-downloaded-modules", excludeDownloaded, "Remove results for downloaded modules in .terraform folder")
 	rootCmd.Flags().BoolVar(&detailedExitCode, "detailed-exit-code", detailedExitCode, "Produce more detailed exit status codes.")
 	rootCmd.Flags().BoolVar(&includePassed, "include-passed", includePassed, "Include passed checks in the result output")
+	rootCmd.Flags().BoolVar(&includeIgnored, "include-ignored", includeIgnored, "Include ignored checks in the result output")
 	rootCmd.Flags().BoolVar(&allDirs, "force-all-dirs", allDirs, "Don't search for tf files, include everything below provided directory.")
 }
 
@@ -255,6 +257,9 @@ func getScannerOptions() []scanner.ScannerOption {
 	var options []scanner.ScannerOption
 	if includePassed {
 		options = append(options, scanner.IncludePassed)
+	}
+	if includeIgnored {
+		options = append(options, scanner.IncludeIgnored)
 	}
 	return options
 }

--- a/internal/app/tfsec/formatters/default.go
+++ b/internal/app/tfsec/formatters/default.go
@@ -110,6 +110,7 @@ func printStatistics() {
 		metrics.BlocksEvaluated,
 		metrics.ModuleLoadCount,
 		metrics.ModuleBlocksLoaded,
+		metrics.IgnoredChecks,
 	} {
 		_ = tml.Printf("  <blue>%-20s</blue> %d\n", name, counts[name])
 	}

--- a/internal/app/tfsec/metrics/metrics.go
+++ b/internal/app/tfsec/metrics/metrics.go
@@ -39,6 +39,7 @@ const (
 	ModuleBlocksLoaded Count = "module blocks"
 	BlocksEvaluated    Count = "evaluated blocks"
 	FilesLoaded        Count = "files loaded"
+	IgnoredChecks      Count = "ignored checks"
 )
 
 var counts = map[Count]int{}
@@ -60,7 +61,5 @@ func TimerSummary() map[Operation]time.Duration {
 }
 
 func CountSummary() map[Count]int {
-
-
 	return counts
 }

--- a/internal/app/tfsec/scanner/scanner.go
+++ b/internal/app/tfsec/scanner/scanner.go
@@ -75,6 +75,10 @@ func (scanner *Scanner) Scan(blocks []*parser.Block, excludedChecksList []string
 						for _, result := range res {
 							if includeIgnored || (!scanner.checkRangeIgnored(result.RuleID, result.Range, block.Range()) && !checkInList(result.RuleID, excludedChecksList)) {
 								results = append(results, result)
+							} else {
+								// check was ignored
+								metrics.Add(metrics.IgnoredChecks, 1)
+								debug.Log("Ignoring '%s' based on tfsec:ignore statement", result.RuleID)
 							}
 						}
 					}
@@ -93,22 +97,20 @@ func (scanner *Scanner) checkRangeIgnored(code RuleCode, r parser.Range, b parse
 	ignoreAll := "tfsec:ignore:*"
 	ignoreCode := fmt.Sprintf("tfsec:ignore:%s", code)
 	lines := append([]string{""}, strings.Split(string(raw), "\n")...)
-	ignoreCheck := false
+	startLine := r.StartLine
+
+	// include the line above the line if available
+	if r.StartLine-1 > 0 {
+		startLine = r.StartLine - 1
+	}
+
 	// check the line itself
-	for number := r.StartLine; number <= r.EndLine; number++ {
+	for number := startLine; number <= r.EndLine; number++ {
 		if number <= 0 || number >= len(lines) {
 			continue
 		}
-		if strings.Contains(lines[number], ignoreAll) || strings.Contains(lines[number], ignoreCode) {
-			ignoreCheck = true
-			break
-		}
-	}
 
-	// check the line above the relevant range
-	if r.StartLine-1 > 0 {
-		line := lines[r.StartLine-1]
-		if ignored := checkLineForIgnore(line, ignoreAll, ignoreCode); ignored {
+		if strings.Contains(lines[number], ignoreAll) || strings.Contains(lines[number], ignoreCode) {
 			return true
 		}
 	}
@@ -121,12 +123,7 @@ func (scanner *Scanner) checkRangeIgnored(code RuleCode, r parser.Range, b parse
 		}
 	}
 
-	if ignoreCheck {
-		metrics.Add(metrics.IgnoredChecks, 1)
-		debug.Log("Ignoring '%s' based on tfsec:ignore statement", code)
-	}
-
-	return ignoreCheck
+	return false
 }
 
 func checkLineForIgnore(line, ignoreAll, ignoreCode string) bool {

--- a/internal/app/tfsec/test/ignore_test.go
+++ b/internal/app/tfsec/test/ignore_test.go
@@ -23,6 +23,17 @@ resource "aws_security_group_rule" "my-rule" {
 
 }
 
+func Test_IgnoreLineAboveTheBlock(t *testing.T) {
+	results := scanSource(`
+// tfsec:ignore:*
+resource "aws_security_group_rule" "my-rule" {
+    type        = "ingress"
+    cidr_blocks = ["0.0.0.0/0"] 
+}
+`)
+	assert.Len(t, results, 0)
+}
+
 func Test_IgnoreSpecific(t *testing.T) {
 
 	scanner.RegisterCheck(scanner.Check{


### PR DESCRIPTION
closes  #664

#### count ignored checks
When using `tfsec:ignore` we might forget about these ignores and it would be good to check how many of these are there to make a decision for instance that we have too many ignores in the project.
![image](https://user-images.githubusercontent.com/312118/113927628-a5ce5580-97e5-11eb-8872-9d8b02b6aa68.png)

#### new flag `--include-ignored`
When checking where are the ignores we could actually try forcing display of them by `tfsec` thus `--include-ignored` flag might be helpful.

#### log ignored checks in debug log
When checking where are the ignores we could also check debug logs to check which rules are actually ignored.
![image](https://user-images.githubusercontent.com/312118/113927825-e037f280-97e5-11eb-98d6-f7a864290c1a.png)
