### PR TITLE
fix: go.sum cleanup

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -272,10 +272,6 @@ github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hashicorp/terraform v0.14.8 h1:m2ytUbgJCAfySARVCd5cjbcMHhtfaozNaDDOFxpZBXk=
-github.com/hashicorp/terraform v0.14.8/go.mod h1:K/LAcRZgbGdSBY+3NB9qdLSPkkFdZ+bTrbzpZ65p4BY=
-github.com/hashicorp/terraform v0.14.9 h1:hZ8s+YuOee7A1o3kOVyBNQs7C4bVqzSHg5TiS6jOkps=
-github.com/hashicorp/terraform v0.14.9/go.mod h1:K/LAcRZgbGdSBY+3NB9qdLSPkkFdZ+bTrbzpZ65p4BY=
 github.com/hashicorp/terraform v0.14.10 h1:hefSc7icxWFW4t8T2BSQ+RPkOiI9YE0otQ8S4EtneZw=
 github.com/hashicorp/terraform v0.14.10/go.mod h1:K/LAcRZgbGdSBY+3NB9qdLSPkkFdZ+bTrbzpZ65p4BY=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
@@ -388,10 +384,6 @@ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/owenrumney/go-sarif v0.0.8 h1:rxNjz+/hm8s4+NUtq1mnvY5NbAr6RqppTzlT+QH2c28=
-github.com/owenrumney/go-sarif v0.0.8/go.mod h1:fcYnVdYRfXWB943S0WaZrjAMuoTEj7vqS7JpOMf6CG0=
-github.com/owenrumney/go-sarif v0.0.9 h1:oplzE8qP8wd63Li57Vt3rB0g1HixVo4OzE5p73FHZis=
-github.com/owenrumney/go-sarif v0.0.9/go.mod h1:fcYnVdYRfXWB943S0WaZrjAMuoTEj7vqS7JpOMf6CG0=
 github.com/owenrumney/go-sarif v1.0.0 h1:Hgic6pTAAV+ozlNDuwIZAU89h0LAdN7UnGXxQvOnHSg=
 github.com/owenrumney/go-sarif v1.0.0/go.mod h1:fcYnVdYRfXWB943S0WaZrjAMuoTEj7vqS7JpOMf6CG0=
 github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db/go.mod h1:f6Izs6JvFTdnRbziASagjZ2vmf55NSIkC/weStxCHqk=


### PR DESCRIPTION
Hi, I tried to alter the _pre-commit_ hook but didn't manage to get the `go mod tidy` such as performed by goreleaser (https://goreleaser.com/customization/hooks/)

Cheers,