### PR TITLE
Pass the context through to each evaluator

### DIFF
--- a/internal/app/tfsec/checks/aws051.go
+++ b/internal/app/tfsec/checks/aws051.go
@@ -46,7 +46,7 @@ func init() {
 
 			kmsKeyIdAttr := block.GetAttribute("kms_key_id")
 			storageEncryptedattr := block.GetAttribute("storage_encrypted")
-
+			
 			if (kmsKeyIdAttr == nil || kmsKeyIdAttr.IsEmpty()) &&
 				(storageEncryptedattr == nil || storageEncryptedattr.IsFalse()) {
 				return []scanner.Result{

--- a/internal/app/tfsec/parser/parser.go
+++ b/internal/app/tfsec/parser/parser.go
@@ -106,7 +106,7 @@ func (parser *Parser) ParseDirectory() (Blocks, error) {
 	var visited []*visitedModule
 
 	debug.Log("Evaluating expressions...")
-	evaluator := NewEvaluator(tfPath, tfPath, blocks, inputVars, modulesMetadata, modules, visited)
+	evaluator := NewEvaluator(tfPath, tfPath, blocks, inputVars, modulesMetadata, modules, visited, nil)
 	evaluatedBlocks, err := evaluator.EvaluateAll()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Each evaluator that is created has a new context, this passes the context through each new one

Potentially Resolve #700 