### PR TITLE
chore: bump Go version in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         stable: 'false'
-        go-version: '1.16.2' # The Go version to download (if necessary) and use.
+        go-version: '1.16.4' # The Go version to download (if necessary) and use.
     - run: go version
 
     - name: Run documentaion Linter
@@ -19,4 +19,3 @@ jobs:
  
     - name: Run test
       run: make test
-

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ push-image:
 
 .PHONY: test
 test:
-	go test -v ./...
+	go test -mod=vendor -v ./...
 
 .PHONY: build
 build:


### PR DESCRIPTION
let's see if this shows the test suite failure mentioned in #719 