### PR TITLE
adding the first Oracle Cloud check 

### DIFF
--- a/internal/app/tfsec/checks/oci001.go
+++ b/internal/app/tfsec/checks/oci001.go
@@ -1,0 +1,66 @@
+package checks
+
+import (
+	"fmt"
+
+	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
+	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
+)
+
+const OCIComputeIpReservation scanner.RuleCode = "OCI001"
+const OCIComputeIpReservationDescription scanner.RuleSummary = "Compute instance requests an IP reservation from a public pool"
+const OCIComputeIpReservationImpact = "The compute instance has the ability to be reached from outside"
+const OCIComputeIpReservationResolution = "Reconsider the use of an public IP"
+const OCIComputeIpReservationExplanation = `
+Compute instance requests an IP reservation from a public pool
+
+The compute instance has the ability to be reached from outside, you might want to sonder the use of a non public IP.
+`
+const OCIComputeIpReservationBadExample = `
+resource "opc_compute_ip_address_reservation" "my-ip-address" {
+	name            = "my-ip-address"
+	ip_address_pool = "public-ippool"
+  }
+`
+const OCIComputeIpReservationGoodExample = `
+resource "opc_compute_ip_address_reservation" "my-ip-address" {
+	name            = "my-ip-address"
+	ip_address_pool = "cloud-ippool"
+  }
+`
+
+func init() {
+	scanner.RegisterCheck(scanner.Check{
+		Code: OCIComputeIpReservation,
+		Documentation: scanner.CheckDocumentation{
+			Summary:     OCIComputeIpReservationDescription,
+			Explanation: OCIComputeIpReservationExplanation,
+			Impact:      OCIComputeIpReservationImpact,
+			Resolution:  OCIComputeIpReservationResolution,
+			BadExample:  OCIComputeIpReservationBadExample,
+			GoodExample: OCIComputeIpReservationGoodExample,
+			Links: []string{
+				"https://registry.terraform.io/providers/hashicorp/opc/latest/docs/resources/opc_compute_ip_address_reservation",
+				"https://registry.terraform.io/providers/hashicorp/opc/latest/docs/resources/opc_compute_instance",
+			},
+		},
+		Provider:       scanner.OracleProvider,
+		RequiredTypes:  []string{"resource"},
+		RequiredLabels: []string{"opc_compute_ip_address_reservation"},
+		CheckFunc: func(check *scanner.Check, block *parser.Block, _ *scanner.Context) []scanner.Result {
+			if attr := block.GetAttribute("ip_address_pool"); attr != nil {
+				if attr.IsAny("public-ippool") {
+					return []scanner.Result{
+						check.NewResultWithValueAnnotation(
+							fmt.Sprintf("Resource '%s' is using an IP from a public IP pool", block.FullName()),
+							attr.Range(),
+							attr,
+							scanner.SeverityWarning,
+						),
+					}
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/internal/app/tfsec/test/oci001_test.go
+++ b/internal/app/tfsec/test/oci001_test.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/tfsec/tfsec/internal/app/tfsec/checks"
+	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
+)
+
+func Test_OCIComputeIpReservation(t *testing.T) {
+
+	var tests = []struct {
+		name                  string
+		source                string
+		mustIncludeResultCode scanner.RuleCode
+		mustExcludeResultCode scanner.RuleCode
+	}{
+		{
+			name: "Check OCI compute IP reservation with ip_address_pool = public-ippool",
+			source: `
+resource "opc_compute_ip_address_reservation" "my-ip-address" {
+	ip_address_pool = "public-ippool"
+}`,
+			mustIncludeResultCode: checks.OCIComputeIpReservation,
+		},
+		{
+			name: "Check OCI compute IP reservation with ip_address_pool = cloud-ippool",
+			source: `
+resource "opc_compute_ip_address_reservation" "my-ip-address" {
+	ip_address_pool = "cloud-ippool"
+}`,
+			mustExcludeResultCode: checks.OCIComputeIpReservation,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results := scanSource(test.source)
+			assertCheckCode(t, test.mustIncludeResultCode, test.mustExcludeResultCode, results)
+		})
+	}
+
+}


### PR DESCRIPTION
Adding the first Oracle Cloud check, it will check on the use of an IP from the external IP pool versus an IP from the internal IP pool. Warning for the use of publicly routable IPs which could expose a customer service to the public internet. 