### PR TITLE
[skip ci] Use official Docker image in docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ There are a number of Docker options available
 To run:
 
 ```bash
-docker run --rm -it -v "$(pwd):/src" liamg/tfsec /src
+docker run --rm -it -v "$(pwd):/src" tfsec/tfsec /src
 ```
 
 ## Use with Visual Studio Code


### PR DESCRIPTION
Seems a bit weird why there's a list of official images, but then tell people to use people to use an "unofficial" image (I know a maintainer made it, but the tfsec namespace is better) that hasn't been updated in the last 3 months :)