### PR TITLE
add in ignore-warnings flag

### DIFF
--- a/cmd/tfsec/main_test.go
+++ b/cmd/tfsec/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/tfsec/tfsec/internal/app/tfsec/scanner"
+	"testing"
+)
+
+func Test_IfIgnoreWarningsSetShouldRemoveWarningScanResults(t *testing.T) {
+	expectedResultsAfterFiltering := 1
+	twoScanResultsWithOneWarning := []scanner.Result {
+		{
+			Severity: scanner.SeverityError,
+		},
+		{
+			Severity: scanner.SeverityWarning,
+		},
+	}
+
+	actualResults := RemoveDuplicatesAndUnwanted(twoScanResultsWithOneWarning, true, false)
+	assert.Len(t, actualResults, expectedResultsAfterFiltering)
+}
+
+func Test_IfIgnoreWarningsIsNotSetThenWarningShouldBeInScanResults(t *testing.T) {
+	expectedResultsAfterFiltering := 2
+	twoScanResultsWithOneWarning := []scanner.Result {
+		{
+			Severity: scanner.SeverityError,
+		},
+		{
+			Severity: scanner.SeverityWarning,
+		},
+	}
+
+	actualResults := RemoveDuplicatesAndUnwanted(twoScanResultsWithOneWarning, false, false)
+	assert.Len(t, actualResults, expectedResultsAfterFiltering)
+}


### PR DESCRIPTION
solves https://github.com/tfsec/tfsec/issues/739

Added also basic unit tests for `main.go`. This requires further improvements and we should move most of the functions used in `main.go` to new module that is covered by unit tests.