### PR TITLE
add custom check action for tags

### DIFF
--- a/internal/app/tfsec/custom/custom_check.go
+++ b/internal/app/tfsec/custom/custom_check.go
@@ -110,6 +110,8 @@ type Check struct {
 	ErrorMessage   string              `json:"errorMessage,omitempty" yaml:"errorMessage,omitempty"`
 	MatchSpec      *MatchSpec          `json:"matchSpec" yaml:"matchSpec"`
 	RelatedLinks   []string            `json:"relatedLinks,omitempty" yaml:"relatedLinks,omitempty"`
+	Impact         string              `json:"impact,omitempty yaml:"impact,omitempty"`
+	Resolution     string              `json:"resolution,omitempty yaml:"resolution,omitempty"`
 }
 
 func (action *CheckAction) isValid() bool {

--- a/internal/app/tfsec/custom/custom_check.go
+++ b/internal/app/tfsec/custom/custom_check.go
@@ -110,8 +110,8 @@ type Check struct {
 	ErrorMessage   string              `json:"errorMessage,omitempty" yaml:"errorMessage,omitempty"`
 	MatchSpec      *MatchSpec          `json:"matchSpec" yaml:"matchSpec"`
 	RelatedLinks   []string            `json:"relatedLinks,omitempty" yaml:"relatedLinks,omitempty"`
-	Impact         string              `json:"impact,omitempty yaml:"impact,omitempty"`
-	Resolution     string              `json:"resolution,omitempty yaml:"resolution,omitempty"`
+	Impact         string              `json:"impact,omitempty" yaml:"impact,omitempty"`
+	Resolution     string              `json:"resolution,omitempty" yaml:"resolution,omitempty"`
 }
 
 func (action *CheckAction) isValid() bool {

--- a/internal/app/tfsec/custom/custom_check.go
+++ b/internal/app/tfsec/custom/custom_check.go
@@ -28,6 +28,7 @@ var ValidCheckActions = []CheckAction{
 	And,
 	Or,
 	Not,
+	HasTag,
 }
 
 // InModule checks that the block is part of a module
@@ -89,6 +90,9 @@ const Or CheckAction = "or"
 
 // Not checks that the given predicateMatchSpec evaluates to False
 const Not CheckAction = "not"
+
+// HasTag checks if there is an expected check for the resource, taking into account provider default checks
+const HasTag CheckAction = "hasTag"
 
 // MatchSpec specifies the checks that should be performed
 type MatchSpec struct {

--- a/internal/app/tfsec/custom/processing.go
+++ b/internal/app/tfsec/custom/processing.go
@@ -115,8 +115,10 @@ func processFoundChecks(checks ChecksFile) {
 			scanner.RegisterCheck(scanner.Check{
 				Code: customCheck.Code,
 				Documentation: scanner.CheckDocumentation{
-					Summary: scanner.RuleSummary(customCheck.Description),
-					Links:   customCheck.RelatedLinks,
+					Summary:    scanner.RuleSummary(customCheck.Description),
+					Links:      customCheck.RelatedLinks,
+					Impact:     customCheck.Impact,
+					Resolution: customCheck.Resolution,
 				},
 				Provider:       "custom",
 				RequiredTypes:  customCheck.RequiredTypes,
@@ -203,10 +205,7 @@ func unpackInterfaceToInterfaceSlice(t interface{}) []interface{} {
 	switch t := t.(type) {
 	case []interface{}:
 		var result []interface{}
-		for _, i := range t {
-			result = append(result, i)
-		}
-		return result
+		return append(result, t...)
 	}
 	return nil
 }

--- a/internal/app/tfsec/scanner/context.go
+++ b/internal/app/tfsec/scanner/context.go
@@ -1,6 +1,11 @@
 package scanner
 
-import "github.com/tfsec/tfsec/internal/app/tfsec/parser"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tfsec/tfsec/internal/app/tfsec/parser"
+)
 
 type Context struct {
 	blocks parser.Blocks
@@ -21,6 +26,23 @@ func (c *Context) GetDatasByType(t string) parser.Blocks {
 	for _, block := range c.blocks {
 		if block.Type() == "data" && len(block.Labels()) > 0 && block.TypeLabel() == t {
 			results = append(results, block)
+		}
+	}
+	return results
+}
+
+func (c *Context) GetProviderBlocksByProvider(providerName string, alias string) parser.Blocks {
+	var results parser.Blocks
+	for _, block := range c.blocks {
+		if block.Type() == "provider" && len(block.Labels()) > 0 && block.TypeLabel() == providerName {
+			if alias != "" {
+				if block.HasChild("alias") && block.GetAttribute("alias").Equals(strings.Replace(alias, fmt.Sprintf("%s.", providerName), "", -1)) {
+					results = append(results, block)
+
+				}
+			} else if block.MissingChild("alias") {
+				results = append(results, block)
+			}
 		}
 	}
 	return results


### PR DESCRIPTION
﻿- Custom checks should still have impact
- fix typo in custom check
- Add check action for tag checking


Closes #755 

custom check becomes 

```yaml
---
checks:
  - code: CUS001
    description: Custom check to ensure the CostCentre tag is applied to EC2 instances
    impact: can't track spend
    resolution: use the cost centre tag
    requiredTypes:
      - resource
    requiredLabels:
      - aws_instance
    severity: ERROR
    matchSpec:
      name: tags
      action: hasTag
      value: CostCentre
    errorMessage: The required CostCentre tag was missing
    relatedLinks:
      - http://internal.acmecorp.com/standards/aws/tagging.html
 ``

