### PR TITLE
ignore date expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ resource "aws_s3_bucket" "my-bucket" {
 }
 ```
 
+### Expiration Date
+You can set expiration date for `ignore` with `yyyy-mm-dd` format. This is a useful feature when you want to ensure ignored issue won't be forgotten and should be revisited in the future.
+```
+#tfsec:ignore:AWS017:2022-01-02
+```
+Ignore like this will be active only till `2022-01-02`, after this date it will be deactivated.
+
 ## Disable checks
 
 You may wish to exclude some checks from running. If you'd like to do so, you can

--- a/internal/app/tfsec/test/ignore_test.go
+++ b/internal/app/tfsec/test/ignore_test.go
@@ -94,3 +94,27 @@ resource "bad" "my-bad" {} //tfsec:ignore:ABC123
 	assert.Equal(t, results[0].RuleID, "DEF456")
 
 }
+
+func Test_IgnoreWithExpDateIfDateBreachedThenDontIgnore(t *testing.T) {
+	results := scanSource(`
+resource "aws_security_group_rule" "my-rule" {
+    type        = "ingress"
+	
+    cidr_blocks = ["0.0.0.0/0"] # tfsec:ignore:AWS006 exp:2000-01-02
+	description = "test security group rule"
+}
+`)
+	assert.Len(t, results, 0)
+}
+
+func Test_IgnoreWithExpDateIfDateNotBreachedThenIgnoreIgnore(t *testing.T) {
+	results := scanSource(`
+resource "aws_security_group_rule" "my-rule" {
+    type        = "ingress"
+	
+    cidr_blocks = ["0.0.0.0/0"] # tfsec:ignore:AWS006 exp:2221-12-02
+	description = "test security group rule"
+}
+`)
+	assert.Len(t, results, 1)
+}

--- a/internal/app/tfsec/test/ignore_test.go
+++ b/internal/app/tfsec/test/ignore_test.go
@@ -143,3 +143,15 @@ resource "aws_security_group_rule" "my-rule" {
 `)
 	assert.Len(t, results, 0)
 }
+
+func Test_IgnoreAboveResourceBlockWithExpDateAndMultipleIgnoresIfDateNotBreachedThenIgnoreIgnore(t *testing.T) {
+	results := scanSource(`
+# tfsec:ignore:AWS006:exp:2221-01-02 #tfsec:ignore:AWS018
+resource "aws_security_group_rule" "my-rule" {
+    type        = "ingress"
+	
+    cidr_blocks = ["0.0.0.0/0"]
+}
+`)
+	assert.Len(t, results, 0)
+}

--- a/internal/app/tfsec/test/ignore_test.go
+++ b/internal/app/tfsec/test/ignore_test.go
@@ -100,11 +100,11 @@ func Test_IgnoreWithExpDateIfDateBreachedThenDontIgnore(t *testing.T) {
 resource "aws_security_group_rule" "my-rule" {
     type        = "ingress"
 	
-    cidr_blocks = ["0.0.0.0/0"] # tfsec:ignore:AWS006 exp:2000-01-02
+    cidr_blocks = ["0.0.0.0/0"] # tfsec:ignore:AWS006:exp:2000-01-02
 	description = "test security group rule"
 }
 `)
-	assert.Len(t, results, 0)
+	assert.Len(t, results, 1)
 }
 
 func Test_IgnoreWithExpDateIfDateNotBreachedThenIgnoreIgnore(t *testing.T) {
@@ -112,9 +112,34 @@ func Test_IgnoreWithExpDateIfDateNotBreachedThenIgnoreIgnore(t *testing.T) {
 resource "aws_security_group_rule" "my-rule" {
     type        = "ingress"
 	
-    cidr_blocks = ["0.0.0.0/0"] # tfsec:ignore:AWS006 exp:2221-12-02
+    cidr_blocks = ["0.0.0.0/0"] # tfsec:ignore:AWS006:exp:2221-01-02
+	description = "test security group rule"
+}
+`)
+	assert.Len(t, results, 0)
+}
+
+func Test_IgnoreWithExpDateIfDateInvalidThenDontIgnoreTheIgnore(t *testing.T) {
+	results := scanSource(`
+resource "aws_security_group_rule" "my-rule" {
+   type        = "ingress"
+
+   cidr_blocks = ["0.0.0.0/0"] # tfsec:ignore:AWS006:exp:2221-13-02
 	description = "test security group rule"
 }
 `)
 	assert.Len(t, results, 1)
+}
+
+func Test_IgnoreAboveResourceBlockWithExpDateIfDateNotBreachedThenIgnoreIgnore(t *testing.T) {
+	results := scanSource(`
+# tfsec:ignore:AWS006:exp:2221-01-02
+resource "aws_security_group_rule" "my-rule" {
+    type        = "ingress"
+	
+    cidr_blocks = ["0.0.0.0/0"]
+	description = "test security group rule"
+}
+`)
+	assert.Len(t, results, 0)
 }


### PR DESCRIPTION
implements https://github.com/tfsec/tfsec/issues/758

### new feature: expiration date for ignore
Adds in expiration date for ignore so that when adding ignore I can decide when I should be reminded about check that I am ignoring.

Current format
```
# tfsec:ignore:AWS006 exp:2221-12-02
```