### PR TITLE
Support scanner option for external tools

### DIFF
--- a/example/external/main.go
+++ b/example/external/main.go
@@ -15,7 +15,7 @@ func main() {
 	_ = scanner.AddPath("../withVars/main.tf")
 	_ = scanner.AddPath("../withVars/variables.tf")
 
-	results, err := scanner.Scan()
+	results, err := scanner.Scan(externalscan.WithIncludedPassed())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
We want to pass scanner.ScannerOption, but it is not exported.
https://github.com/tfsec/tfsec/blob/master/internal/app/tfsec/scanner/scanner.go#L19

This PR allows external tools to pass those options. If you prefer exporting scanner.ScannerOption directly or any other ideas, please let me know.