### PR TITLE
Add the root block to the result

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Now all that's left is writing the logic itself. You'll likely find it useful he
             if attr := block.GetAttribute("hackable"); attr != nil && attr.Value().Type() == cty.Bool {
                 if attr.Value().True() {
                     set.Add(
-                        result.New().
+                        result.New(resourceBlock).
 						WithDescription(fmt.Sprintf("The Gibson '%s' is configured to be hackable.", block.Name())).
 						WithRange(attr.Range()).
 						WithAttributeAnnotation(attr).

--- a/internal/app/tfsec/custom/processing.go
+++ b/internal/app/tfsec/custom/processing.go
@@ -136,7 +136,7 @@ func processFoundChecks(checks ChecksFile) {
 					matchSpec := customCheck.MatchSpec
 					if !evalMatchSpec(rootBlock, matchSpec, ctx) {
 						set.Add(
-							result.New().
+							result.New(rootBlock).
 								WithDescription(fmt.Sprintf("Custom check failed for resource %s. %s", rootBlock.FullName(), customCheck.ErrorMessage)).
 								WithRange(rootBlock.Range()).
 								WithSeverity(customCheck.Severity),

--- a/internal/app/tfsec/rules/aws001.go
+++ b/internal/app/tfsec/rules/aws001.go
@@ -57,20 +57,20 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_s3_bucket"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if attr := block.GetAttribute("acl"); attr != nil {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if attr := resourceBlock.GetAttribute("acl"); attr != nil {
 				if attr.IsAny("public-read", "public-read-write", "website") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has an ACL which allows public access.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has an ACL which allows public access.", resourceBlock.FullName())).
 							WithAttributeAnnotation(attr).
 							WithRange(attr.Range()).
 							WithSeverity(severity.Warning),
 					)
 				} else if attr.Equals("authenticated-read") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has an ACL which allows access to any authenticated AWS user, not just users within the target account.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has an ACL which allows access to any authenticated AWS user, not just users within the target account.", resourceBlock.FullName())).
 							WithRange(attr.Range()).
 							WithSeverity(severity.Warning),
 					)

--- a/internal/app/tfsec/rules/aws002.go
+++ b/internal/app/tfsec/rules/aws002.go
@@ -55,15 +55,15 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_s3_bucket"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if loggingBlock := block.GetBlock("logging"); loggingBlock == nil {
-				if block.GetAttribute("acl") != nil && block.GetAttribute("acl").Equals("log-delivery-write") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if loggingBlock := resourceBlock.GetBlock("logging"); loggingBlock == nil {
+				if resourceBlock.GetAttribute("acl") != nil && resourceBlock.GetAttribute("acl").Equals("log-delivery-write") {
 					return
 				}
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have logging enabled.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have logging enabled.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/aws003.go
+++ b/internal/app/tfsec/rules/aws003.go
@@ -53,11 +53,11 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_db_security_group", "aws_redshift_security_group", "aws_elasticache_security_group"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			set.Add(
-				result.New().
-					WithDescription(fmt.Sprintf("Resource '%s' uses EC2 Classic. Use a VPC instead.", block.FullName())).
-					WithRange(block.Range()).
+				result.New(resourceBlock).
+					WithDescription(fmt.Sprintf("Resource '%s' uses EC2 Classic. Use a VPC instead.", resourceBlock.FullName())).
+					WithRange(resourceBlock.Range()).
 					WithSeverity(severity.Error),
 			)
 		},

--- a/internal/app/tfsec/rules/aws004.go
+++ b/internal/app/tfsec/rules/aws004.go
@@ -57,12 +57,12 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_lb_listener", "aws_alb_listener"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if protocolAttr := block.GetAttribute("protocol"); protocolAttr == nil || (protocolAttr.Type() == cty.String && protocolAttr.Value().AsString() == "HTTP") {
+			if protocolAttr := resourceBlock.GetAttribute("protocol"); protocolAttr == nil || (protocolAttr.Type() == cty.String && protocolAttr.Value().AsString() == "HTTP") {
 
 				// check if this is a redirect to HTTPS - if it is, then no problem
-				if actionBlock := block.GetBlock("default_action"); actionBlock != nil {
+				if actionBlock := resourceBlock.GetBlock("default_action"); actionBlock != nil {
 					actionTypeAttr := actionBlock.GetAttribute("type")
 					if actionTypeAttr != nil && actionTypeAttr.Type() == cty.String && actionTypeAttr.Value().AsString() == "redirect" {
 						if redirectBlock := actionBlock.GetBlock("redirect"); redirectBlock != nil {
@@ -74,15 +74,15 @@ func init() {
 					}
 				}
 
-				res := result.New().
-					WithDescription(fmt.Sprintf("Resource '%s' uses plain HTTP instead of HTTPS.", block.FullName())).
+				res := result.New(resourceBlock).
+					WithDescription(fmt.Sprintf("Resource '%s' uses plain HTTP instead of HTTPS.", resourceBlock.FullName())).
 					WithSeverity(severity.Error)
 
 				if protocolAttr != nil {
 					res.WithRange(protocolAttr.Range()).
 						WithAttributeAnnotation(protocolAttr)
 				} else {
-					res.WithRange(block.Range())
+					res.WithRange(resourceBlock.Range())
 				}
 
 				set.Add(res)

--- a/internal/app/tfsec/rules/aws005.go
+++ b/internal/app/tfsec/rules/aws005.go
@@ -54,18 +54,18 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_alb", "aws_elb", "aws_lb"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if internalAttr := block.GetAttribute("internal"); internalAttr == nil {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if internalAttr := resourceBlock.GetAttribute("internal"); internalAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is exposed publicly.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is exposed publicly.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			} else if internalAttr.Type() == cty.Bool && internalAttr.Value().False() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is exposed publicly.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is exposed publicly.", resourceBlock.FullName())).
 						WithRange(internalAttr.Range()).
 						WithAttributeAnnotation(internalAttr).
 						WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws006.go
+++ b/internal/app/tfsec/rules/aws006.go
@@ -56,9 +56,9 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_security_group_rule"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			typeAttr := block.GetAttribute("type")
+			typeAttr := resourceBlock.GetAttribute("type")
 			if typeAttr == nil || typeAttr.Type() != cty.String {
 				return
 			}
@@ -67,22 +67,22 @@ func init() {
 				return
 			}
 
-			if cidrBlocksAttr := block.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
+			if cidrBlocksAttr := resourceBlock.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
 				if isOpenCidr(cidrBlocksAttr) {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", resourceBlock.FullName())).
 							WithRange(cidrBlocksAttr.Range()).
 							WithSeverity(severity.Warning),
 					)
 				}
 			}
 
-			if ipv6CidrBlocksAttr := block.GetAttribute("ipv6_cidr_blocks"); ipv6CidrBlocksAttr != nil {
+			if ipv6CidrBlocksAttr := resourceBlock.GetAttribute("ipv6_cidr_blocks"); ipv6CidrBlocksAttr != nil {
 				if isOpenCidr(ipv6CidrBlocksAttr) {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", resourceBlock.FullName())).
 							WithRange(ipv6CidrBlocksAttr.Range()).
 							WithAttributeAnnotation(ipv6CidrBlocksAttr).
 							WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws007.go
+++ b/internal/app/tfsec/rules/aws007.go
@@ -56,9 +56,9 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_security_group_rule"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			typeAttr := block.GetAttribute("type")
+			typeAttr := resourceBlock.GetAttribute("type")
 			if typeAttr == nil || typeAttr.Type() != cty.String {
 				return
 			}
@@ -67,12 +67,12 @@ func init() {
 				return
 			}
 
-			if cidrBlocksAttr := block.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
+			if cidrBlocksAttr := resourceBlock.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
 
 				if isOpenCidr(cidrBlocksAttr) {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open egress security group rule.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open egress security group rule.", resourceBlock.FullName())).
 							WithRange(cidrBlocksAttr.Range()).
 							WithAttributeAnnotation(cidrBlocksAttr).
 							WithSeverity(severity.Warning),
@@ -80,12 +80,12 @@ func init() {
 				}
 			}
 
-			if ipv6CidrBlocksAttr := block.GetAttribute("ipv6_cidr_blocks"); ipv6CidrBlocksAttr != nil {
+			if ipv6CidrBlocksAttr := resourceBlock.GetAttribute("ipv6_cidr_blocks"); ipv6CidrBlocksAttr != nil {
 
 				if isOpenCidr(ipv6CidrBlocksAttr) {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open egress security group rule.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open egress security group rule.", resourceBlock.FullName())).
 							WithRange(ipv6CidrBlocksAttr.Range()).
 							WithAttributeAnnotation(ipv6CidrBlocksAttr).
 							WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws008.go
+++ b/internal/app/tfsec/rules/aws008.go
@@ -56,15 +56,15 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_security_group"},
-		CheckFunc: func(resultSet result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(resultSet result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			for _, directionBlock := range block.GetBlocks("ingress") {
+			for _, directionBlock := range resourceBlock.GetBlocks("ingress") {
 				if cidrBlocksAttr := directionBlock.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
 
 					if isOpenCidr(cidrBlocksAttr) {
 						resultSet.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress security group.", block.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress security group.", resourceBlock.FullName())).
 								WithRange(cidrBlocksAttr.Range()).
 								WithAttributeAnnotation(cidrBlocksAttr).
 								WithSeverity(severity.Warning),
@@ -76,8 +76,8 @@ func init() {
 
 					if isOpenCidr(cidrBlocksAttr) {
 						resultSet.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress security group.", block.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress security group.", resourceBlock.FullName())).
 								WithRange(cidrBlocksAttr.Range()).
 								WithSeverity(severity.Warning),
 						)

--- a/internal/app/tfsec/rules/aws009.go
+++ b/internal/app/tfsec/rules/aws009.go
@@ -56,15 +56,15 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_security_group"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			for _, directionBlock := range block.GetBlocks("egress") {
+			for _, directionBlock := range resourceBlock.GetBlocks("egress") {
 				if cidrBlocksAttr := directionBlock.GetAttribute("cidr_blocks"); cidrBlocksAttr != nil {
 
 					if isOpenCidr(cidrBlocksAttr) {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open egress security group.", block.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open egress security group.", resourceBlock.FullName())).
 								WithRange(cidrBlocksAttr.Range()).
 								WithAttributeAnnotation(cidrBlocksAttr).
 								WithSeverity(severity.Warning),
@@ -76,8 +76,8 @@ func init() {
 
 					if isOpenCidr(cidrBlocksAttr) {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open egress security group.", block.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open egress security group.", resourceBlock.FullName())).
 								WithRange(cidrBlocksAttr.Range()).
 								WithAttributeAnnotation(cidrBlocksAttr).
 								WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws010.go
+++ b/internal/app/tfsec/rules/aws010.go
@@ -64,14 +64,14 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_lb_listener", "aws_alb_listener"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if sslPolicyAttr := block.GetAttribute("ssl_policy"); sslPolicyAttr != nil && sslPolicyAttr.Type() == cty.String {
+			if sslPolicyAttr := resourceBlock.GetAttribute("ssl_policy"); sslPolicyAttr != nil && sslPolicyAttr.Type() == cty.String {
 				for _, policy := range outdatedSSLPolicies {
 					if policy == sslPolicyAttr.Value().AsString() {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' is using an outdated SSL policy.", block.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' is using an outdated SSL policy.", resourceBlock.FullName())).
 								WithRange(sslPolicyAttr.Range()).
 								WithAttributeAnnotation(sslPolicyAttr).
 								WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws011.go
+++ b/internal/app/tfsec/rules/aws011.go
@@ -54,13 +54,13 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_db_instance", "aws_dms_replication_instance", "aws_rds_cluster_instance", "aws_redshift_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if publicAttr := block.GetAttribute("publicly_accessible"); publicAttr != nil && publicAttr.Type() == cty.Bool {
+			if publicAttr := resourceBlock.GetAttribute("publicly_accessible"); publicAttr != nil && publicAttr.Type() == cty.Bool {
 				if publicAttr.Value().True() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' is exposed publicly.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' is exposed publicly.", resourceBlock.FullName())).
 							WithRange(publicAttr.Range()).
 							WithAttributeAnnotation(publicAttr).
 							WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws012.go
+++ b/internal/app/tfsec/rules/aws012.go
@@ -56,13 +56,13 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_launch_configuration", "aws_instance"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if publicAttr := block.GetAttribute("associate_public_ip_address"); publicAttr != nil && publicAttr.Type() == cty.Bool {
+			if publicAttr := resourceBlock.GetAttribute("associate_public_ip_address"); publicAttr != nil && publicAttr.Type() == cty.Bool {
 				if publicAttr.Value().True() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has a public IP address associated.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has a public IP address associated.", resourceBlock.FullName())).
 							WithRange(publicAttr.Range()).
 							WithAttributeAnnotation(publicAttr).
 							WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws013.go
+++ b/internal/app/tfsec/rules/aws013.go
@@ -83,9 +83,9 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_ecs_task_definition"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if definitionsAttr := block.GetAttribute("container_definitions"); definitionsAttr != nil && definitionsAttr.Type() == cty.String {
+			if definitionsAttr := resourceBlock.GetAttribute("container_definitions"); definitionsAttr != nil && definitionsAttr.Type() == cty.String {
 				rawJSON := []byte(definitionsAttr.Value().AsString())
 
 				var definitions []struct {
@@ -101,8 +101,8 @@ func init() {
 				for _, definition := range definitions {
 					for _, env := range definition.EnvVars {
 						if security.IsSensitiveAttribute(env.Name) && env.Value != "" {
-							set.Add(result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' includes a potentially sensitive environment variable '%s' in the container definition.", block.FullName(), env.Name)).
+							set.Add(result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' includes a potentially sensitive environment variable '%s' in the container definition.", resourceBlock.FullName(), env.Name)).
 								WithRange(definitionsAttr.Range()).
 								WithAttributeAnnotation(definitionsAttr).
 								WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws014.go
+++ b/internal/app/tfsec/rules/aws014.go
@@ -59,7 +59,7 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_launch_configuration"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			var encryptionByDefault bool
 
@@ -70,27 +70,27 @@ func init() {
 				}
 			}
 
-			rootDeviceBlock := block.GetBlock("root_block_device")
+			rootDeviceBlock := resourceBlock.GetBlock("root_block_device")
 			if rootDeviceBlock == nil && !encryptionByDefault {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' uses an unencrypted root EBS block device. Consider adding <blue>root_block_device{ encrypted = true }</blue>", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' uses an unencrypted root EBS block device. Consider adding <blue>root_block_device{ encrypted = true }</blue>", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			} else if rootDeviceBlock != nil {
 				encryptedAttr := rootDeviceBlock.GetAttribute("encrypted")
 				if encryptedAttr == nil && !encryptionByDefault {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' uses an unencrypted root EBS block device. Consider adding <blue>encrypted = true</blue>", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' uses an unencrypted root EBS block device. Consider adding <blue>encrypted = true</blue>", resourceBlock.FullName())).
 							WithRange(rootDeviceBlock.Range()).
 							WithSeverity(severity.Error),
 					)
 				} else if encryptedAttr != nil && encryptedAttr.Type() == cty.Bool && encryptedAttr.Value().False() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' uses an unencrypted root EBS block device.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' uses an unencrypted root EBS block device.", resourceBlock.FullName())).
 							WithRange(encryptedAttr.Range()).
 							WithAttributeAnnotation(encryptedAttr).
 							WithSeverity(severity.Error),
@@ -98,20 +98,20 @@ func init() {
 				}
 			}
 
-			ebsDeviceBlocks := block.GetBlocks("ebs_block_device")
+			ebsDeviceBlocks := resourceBlock.GetBlocks("ebs_block_device")
 			for _, ebsDeviceBlock := range ebsDeviceBlocks {
 				encryptedAttr := ebsDeviceBlock.GetAttribute("encrypted")
 				if encryptedAttr == nil && !encryptionByDefault {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' uses an unencrypted EBS block device. Consider adding <blue>encrypted = true</blue>", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' uses an unencrypted EBS block device. Consider adding <blue>encrypted = true</blue>", resourceBlock.FullName())).
 							WithRange(ebsDeviceBlock.Range()).
 							WithSeverity(severity.Error),
 					)
 				} else if encryptedAttr != nil && encryptedAttr.Type() == cty.Bool && encryptedAttr.Value().False() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' uses an unencrypted EBS block device.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' uses an unencrypted EBS block device.", resourceBlock.FullName())).
 							WithRange(encryptedAttr.Range()).
 							WithAttributeAnnotation(encryptedAttr).
 							WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws015.go
+++ b/internal/app/tfsec/rules/aws015.go
@@ -55,21 +55,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_sqs_queue"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			kmsKeyIDAttr := block.GetAttribute("kms_master_key_id")
+			kmsKeyIDAttr := resourceBlock.GetAttribute("kms_master_key_id")
 			if kmsKeyIDAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted SQS queue.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted SQS queue.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 
 			} else if kmsKeyIDAttr.Type() == cty.String && kmsKeyIDAttr.Value().AsString() == "" {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted SQS queue.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted SQS queue.", resourceBlock.FullName())).
 						WithRange(kmsKeyIDAttr.Range()).
 						WithAttributeAnnotation(kmsKeyIDAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws016.go
+++ b/internal/app/tfsec/rules/aws016.go
@@ -56,21 +56,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_sns_topic"},
-		CheckFunc: func(set result.Set, block *block.Block, ctx *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, ctx *hclcontext.Context) {
 
-			kmsKeyIDAttr := block.GetAttribute("kms_master_key_id")
+			kmsKeyIDAttr := resourceBlock.GetAttribute("kms_master_key_id")
 			if kmsKeyIDAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted SNS topic.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted SNS topic.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
 			} else if kmsKeyIDAttr.Type() == cty.String && kmsKeyIDAttr.Value().AsString() == "" {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted SNS topic.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted SNS topic.", resourceBlock.FullName())).
 						WithRange(kmsKeyIDAttr.Range()).
 						WithAttributeAnnotation(kmsKeyIDAttr).
 						WithSeverity(severity.Error),
@@ -91,8 +91,8 @@ func init() {
 						keyIdAttr := kmsData.GetAttribute("key_id")
 						if keyIdAttr != nil && keyIdAttr.Equals("alias/aws/sns") {
 							set.Add(
-								result.New().
-									WithDescription(fmt.Sprintf("Resource '%s' explicitly uses the default CMK", block.FullName())).
+								result.New(resourceBlock).
+									WithDescription(fmt.Sprintf("Resource '%s' explicitly uses the default CMK", resourceBlock.FullName())).
 									WithRange(kmsKeyIDAttr.Range()).
 									WithAttributeAnnotation(kmsKeyIDAttr).
 									WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws017.go
+++ b/internal/app/tfsec/rules/aws017.go
@@ -62,21 +62,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_s3_bucket"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			if block.MissingChild("server_side_encryption_configuration") {
+			if resourceBlock.MissingChild("server_side_encryption_configuration") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing server_side_encryption_configuration block).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing server_side_encryption_configuration block).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
-			encryptionBlock := block.GetBlock("server_side_encryption_configuration")
+			encryptionBlock := resourceBlock.GetBlock("server_side_encryption_configuration")
 			if encryptionBlock.MissingChild("rule") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing rule block).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing rule block).", resourceBlock.FullName())).
 						WithRange(encryptionBlock.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -86,8 +86,8 @@ func init() {
 
 			if ruleBlock.MissingChild("apply_server_side_encryption_by_default") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing apply_server_side_encryption_by_default block).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing apply_server_side_encryption_by_default block).", resourceBlock.FullName())).
 						WithRange(ruleBlock.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -96,8 +96,8 @@ func init() {
 			applyBlock := ruleBlock.GetBlock("apply_server_side_encryption_by_default")
 			if sseAttr := applyBlock.GetAttribute("sse_algorithm"); sseAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing sse_algorithm attribute).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted S3 bucket (missing sse_algorithm attribute).", resourceBlock.FullName())).
 						WithRange(applyBlock.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/aws018.go
+++ b/internal/app/tfsec/rules/aws018.go
@@ -74,22 +74,22 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_security_group", "aws_security_group_rule"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if block.MissingChild("description") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.MissingChild("description") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should include a description for auditing purposes.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should include a description for auditing purposes.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
 			}
 
-			descriptionAttr := block.GetAttribute("description")
+			descriptionAttr := resourceBlock.GetAttribute("description")
 			if descriptionAttr.IsEmpty() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should include a non-empty description for auditing purposes.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should include a non-empty description for auditing purposes.", resourceBlock.FullName())).
 						WithRange(descriptionAttr.Range()).
 						WithAttributeAnnotation(descriptionAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws019.go
+++ b/internal/app/tfsec/rules/aws019.go
@@ -56,20 +56,20 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_kms_key"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			keyUsageAttr := block.GetAttribute("key_usage")
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			keyUsageAttr := resourceBlock.GetAttribute("key_usage")
 
 			if keyUsageAttr != nil && keyUsageAttr.Equals("SIGN_VERIFY") {
 				return
 			}
 
-			keyRotationAttr := block.GetAttribute("enable_key_rotation")
+			keyRotationAttr := resourceBlock.GetAttribute("enable_key_rotation")
 
 			if keyRotationAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have KMS Key auto-rotation enabled.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have KMS Key auto-rotation enabled.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 				return
@@ -77,8 +77,8 @@ func init() {
 
 			if keyRotationAttr.Type() == cty.Bool && keyRotationAttr.Value().False() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have KMS Key auto-rotation enabled.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have KMS Key auto-rotation enabled.", resourceBlock.FullName())).
 						WithRange(keyRotationAttr.Range()).
 						WithAttributeAnnotation(keyRotationAttr).
 						WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws020.go
+++ b/internal/app/tfsec/rules/aws020.go
@@ -61,29 +61,29 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudfront_distribution"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			defaultBehaviorBlock := block.GetBlock("default_cache_behavior")
+			defaultBehaviorBlock := resourceBlock.GetBlock("default_cache_behavior")
 			if defaultBehaviorBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications (missing default_cache_behavior block).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications (missing default_cache_behavior block).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			} else {
 				protocolPolicyAttr := defaultBehaviorBlock.GetAttribute("viewer_protocol_policy")
 				if protocolPolicyAttr == nil {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications (missing viewer_protocol_policy block).", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications (missing viewer_protocol_policy block).", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Error),
 					)
 				} else if protocolPolicyAttr.Type() == cty.String && protocolPolicyAttr.Value().AsString() == "allow-all" {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications.", resourceBlock.FullName())).
 							WithRange(protocolPolicyAttr.Range()).
 							WithAttributeAnnotation(protocolPolicyAttr).
 							WithSeverity(severity.Error),
@@ -91,20 +91,20 @@ func init() {
 				}
 			}
 
-			orderedBehaviorBlocks := block.GetBlocks("ordered_cache_behavior")
+			orderedBehaviorBlocks := resourceBlock.GetBlocks("ordered_cache_behavior")
 			for _, orderedBehaviorBlock := range orderedBehaviorBlocks {
 				orderedProtocolPolicyAttr := orderedBehaviorBlock.GetAttribute("viewer_protocol_policy")
 				if orderedProtocolPolicyAttr == nil {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications (missing viewer_protocol_policy block).", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications (missing viewer_protocol_policy block).", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Error),
 					)
 				} else if orderedProtocolPolicyAttr.Type() == cty.String && orderedProtocolPolicyAttr.Value().AsString() == "allow-all" {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a CloudFront distribution that allows unencrypted communications.", resourceBlock.FullName())).
 							WithRange(orderedProtocolPolicyAttr.Range()).
 							WithAttributeAnnotation(orderedProtocolPolicyAttr).
 							WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws021.go
+++ b/internal/app/tfsec/rules/aws021.go
@@ -61,29 +61,29 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudfront_distribution"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			viewerCertificateBlock := block.GetBlock("viewer_certificate")
+			viewerCertificateBlock := resourceBlock.GetBlock("viewer_certificate")
 			if viewerCertificateBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (missing viewer_certificate block)", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (missing viewer_certificate block)", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
 			if minVersion := viewerCertificateBlock.GetAttribute("minimum_protocol_version"); minVersion == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (missing minimum_protocol_version attribute)", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (missing minimum_protocol_version attribute)", resourceBlock.FullName())).
 						WithRange(viewerCertificateBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			} else if minVersion.Type() == cty.String && minVersion.Value().AsString() != "TLSv1.2_2019" {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (not using TLSv1.2_2019)", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (not using TLSv1.2_2019)", resourceBlock.FullName())).
 						WithRange(minVersion.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/aws022.go
+++ b/internal/app/tfsec/rules/aws022.go
@@ -64,14 +64,14 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_msk_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			defaultBehaviorBlock := block.GetBlock("encryption_info")
+			defaultBehaviorBlock := resourceBlock.GetBlock("encryption_info")
 			if defaultBehaviorBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing encryption_info block).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing encryption_info block).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 				return
@@ -80,32 +80,32 @@ func init() {
 			encryptionInTransit := defaultBehaviorBlock.GetBlock("encryption_in_transit")
 			if encryptionInTransit == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing encryption_in_transit block).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing encryption_in_transit block).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			} else {
 				clientBrokerAttr := encryptionInTransit.GetAttribute("client_broker")
 				if clientBrokerAttr == nil {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing client_broker block).", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit (missing client_broker block).", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Warning),
 					)
 				} else if clientBrokerAttr.Value().AsString() == "PLAINTEXT" {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a MSK cluster that only allows plaintext data in transit.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a MSK cluster that only allows plaintext data in transit.", resourceBlock.FullName())).
 							WithRange(clientBrokerAttr.Range()).
 							WithAttributeAnnotation(clientBrokerAttr).
 							WithSeverity(severity.Error),
 					)
 				} else if clientBrokerAttr.Value().AsString() == "TLS_PLAINTEXT" {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a MSK cluster that allows plaintext as well as TLS encrypted data in transit.", resourceBlock.FullName())).
 							WithRange(clientBrokerAttr.Range()).
 							WithAttributeAnnotation(clientBrokerAttr).
 							WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws023.go
+++ b/internal/app/tfsec/rules/aws023.go
@@ -66,22 +66,22 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_ecr_repository"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			ecrScanStatusBlock := block.GetBlock("image_scanning_configuration")
+			ecrScanStatusBlock := resourceBlock.GetBlock("image_scanning_configuration")
 			ecrScanStatusAttr := ecrScanStatusBlock.GetAttribute("scan_on_push")
 
 			if ecrScanStatusAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a disabled ECR image scan.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a disabled ECR image scan.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			} else if ecrScanStatusAttr.Type() == cty.Bool && ecrScanStatusAttr.Value().False() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a disabled ECR image scan.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a disabled ECR image scan.", resourceBlock.FullName())).
 						WithRange(ecrScanStatusAttr.Range()).
 						WithAttributeAnnotation(ecrScanStatusAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws024.go
+++ b/internal/app/tfsec/rules/aws024.go
@@ -57,31 +57,31 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_kinesis_stream"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			encryptionTypeAttr := block.GetAttribute("encryption_type")
+			encryptionTypeAttr := resourceBlock.GetAttribute("encryption_type")
 			if encryptionTypeAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Kinesis Stream.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Kinesis Stream.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			} else if encryptionTypeAttr.Type() == cty.String && strings.ToUpper(encryptionTypeAttr.Value().AsString()) != "KMS" {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Kinesis Stream.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Kinesis Stream.", resourceBlock.FullName())).
 						WithRange(encryptionTypeAttr.Range()).
 						WithAttributeAnnotation(encryptionTypeAttr).
 						WithSeverity(severity.Error),
 				)
 			} else {
-				keyIDAttr := block.GetAttribute("kms_key_id")
+				keyIDAttr := resourceBlock.GetAttribute("kms_key_id")
 				if keyIDAttr == nil || keyIDAttr.IsEmpty() || keyIDAttr.Equals("alias/aws/kinesis") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a Kinesis Stream encrypted with the default Kinesis key.", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a Kinesis Stream encrypted with the default Kinesis key.", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Warning),
 					)
 				}

--- a/internal/app/tfsec/rules/aws025.go
+++ b/internal/app/tfsec/rules/aws025.go
@@ -55,22 +55,22 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_api_gateway_domain_name"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			securityPolicyAttr := block.GetAttribute("security_policy")
+			securityPolicyAttr := resourceBlock.GetAttribute("security_policy")
 			if securityPolicyAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should include security_policy (defauls to outdated SSL/TLS policy).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should include security_policy (defauls to outdated SSL/TLS policy).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
 			if securityPolicyAttr.Type() == cty.String && securityPolicyAttr.Value().AsString() != "TLS_1_2" {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (not using TLS_1_2).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines outdated SSL/TLS policies (not using TLS_1_2).", resourceBlock.FullName())).
 						WithRange(securityPolicyAttr.Range()).
 						WithAttributeAnnotation(securityPolicyAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws031.go
+++ b/internal/app/tfsec/rules/aws031.go
@@ -63,14 +63,14 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticsearch_domain"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			encryptionBlock := block.GetBlock("encrypt_at_rest")
+			encryptionBlock := resourceBlock.GetBlock("encrypt_at_rest")
 			if encryptionBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticsearch domain (missing encrypt_at_rest block).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticsearch domain (missing encrypt_at_rest block).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
@@ -78,8 +78,8 @@ func init() {
 			enabledAttr := encryptionBlock.GetAttribute("enabled")
 			if enabledAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticsearch domain (missing enabled attribute).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticsearch domain (missing enabled attribute).", resourceBlock.FullName())).
 						WithRange(encryptionBlock.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -91,8 +91,8 @@ func init() {
 			encryptionEnabled := isTrueBool || isTrueString
 			if !encryptionEnabled {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticsearch domain (enabled attribute set to false).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticsearch domain (enabled attribute set to false).", resourceBlock.FullName())).
 						WithRange(encryptionBlock.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/aws032.go
+++ b/internal/app/tfsec/rules/aws032.go
@@ -64,14 +64,14 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticsearch_domain"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			encryptionBlock := block.GetBlock("node_to_node_encryption")
+			encryptionBlock := resourceBlock.GetBlock("node_to_node_encryption")
 			if encryptionBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing node_to_node_encryption block).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing node_to_node_encryption block).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
@@ -79,8 +79,8 @@ func init() {
 			enabledAttr := encryptionBlock.GetAttribute("enabled")
 			if enabledAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing enabled attribute).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing enabled attribute).", resourceBlock.FullName())).
 						WithRange(encryptionBlock.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -92,8 +92,8 @@ func init() {
 			nodeToNodeEncryptionEnabled := isTrueBool || isTrueString
 			if !nodeToNodeEncryptionEnabled {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (enabled attribute set to false).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (enabled attribute set to false).", resourceBlock.FullName())).
 						WithRange(encryptionBlock.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/aws033.go
+++ b/internal/app/tfsec/rules/aws033.go
@@ -67,14 +67,14 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticsearch_domain"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			endpointBlock := block.GetBlock("domain_endpoint_options")
+			endpointBlock := resourceBlock.GetBlock("domain_endpoint_options")
 			if endpointBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing domain_endpoint_options block).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing domain_endpoint_options block).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
@@ -82,8 +82,8 @@ func init() {
 			enforceHTTPSAttr := endpointBlock.GetAttribute("enforce_https")
 			if enforceHTTPSAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing enforce_https attribute).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (missing enforce_https attribute).", resourceBlock.FullName())).
 						WithRange(endpointBlock.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -95,8 +95,8 @@ func init() {
 			enforcedHTTPS := isTrueBool || isTrueString
 			if !enforcedHTTPS {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (enabled attribute set to false).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with plaintext traffic (enabled attribute set to false).", resourceBlock.FullName())).
 						WithRange(endpointBlock.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/aws034.go
+++ b/internal/app/tfsec/rules/aws034.go
@@ -65,9 +65,9 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticsearch_domain"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			endpointBlock := block.GetBlock("domain_endpoint_options")
+			endpointBlock := resourceBlock.GetBlock("domain_endpoint_options")
 			if endpointBlock == nil {
 				// Rule AWS033 covers this case.
 				return
@@ -76,8 +76,8 @@ func init() {
 			tlsPolicyAttr := endpointBlock.GetAttribute("tls_security_policy")
 			if tlsPolicyAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with an outdated TLS policy (defaults to Policy-Min-TLS-1-0-2019-07).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with an outdated TLS policy (defaults to Policy-Min-TLS-1-0-2019-07).", resourceBlock.FullName())).
 						WithRange(endpointBlock.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -86,8 +86,8 @@ func init() {
 
 			if tlsPolicyAttr.Value().Equals(cty.StringVal("Policy-Min-TLS-1-0-2019-07")).True() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with an outdated TLS policy (set to Policy-Min-TLS-1-0-2019-07).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an Elasticsearch domain with an outdated TLS policy (set to Policy-Min-TLS-1-0-2019-07).", resourceBlock.FullName())).
 						WithRange(tlsPolicyAttr.Range()).
 						WithAttributeAnnotation(tlsPolicyAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws035.go
+++ b/internal/app/tfsec/rules/aws035.go
@@ -59,20 +59,20 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticache_replication_group"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			encryptionAttr := block.GetAttribute("at_rest_encryption_enabled")
+			encryptionAttr := resourceBlock.GetAttribute("at_rest_encryption_enabled")
 			if encryptionAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (missing at_rest_encryption_enabled attribute).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (missing at_rest_encryption_enabled attribute).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			} else if !isBooleanOrStringTrue(encryptionAttr) {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (at_rest_encryption_enabled set to false).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (at_rest_encryption_enabled set to false).", resourceBlock.FullName())).
 						WithRange(encryptionAttr.Range()).
 						WithAttributeAnnotation(encryptionAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws036.go
+++ b/internal/app/tfsec/rules/aws036.go
@@ -59,20 +59,20 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticache_replication_group"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			encryptionAttr := block.GetAttribute("transit_encryption_enabled")
+			encryptionAttr := resourceBlock.GetAttribute("transit_encryption_enabled")
 			if encryptionAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (missing transit_encryption_enabled attribute).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (missing transit_encryption_enabled attribute).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			} else if !isBooleanOrStringTrue(encryptionAttr) {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (transit_encryption_enabled set to false).", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted Elasticache Replication Group (transit_encryption_enabled set to false).", resourceBlock.FullName())).
 						WithRange(encryptionAttr.Range()).
 						WithAttributeAnnotation(encryptionAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws037.go
+++ b/internal/app/tfsec/rules/aws037.go
@@ -64,21 +64,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_iam_account_password_policy"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if attr := block.GetAttribute("password_reuse_prevention"); attr == nil {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if attr := resourceBlock.GetAttribute("password_reuse_prevention"); attr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have a password reuse prevention count set.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have a password reuse prevention count set.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			} else if attr.Value().Type() == cty.Number {
 				value, _ := attr.Value().AsBigFloat().Float64()
 				if value < 5 {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has a password reuse count less than 5.", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has a password reuse count less than 5.", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Warning),
 					)
 				}

--- a/internal/app/tfsec/rules/aws038.go
+++ b/internal/app/tfsec/rules/aws038.go
@@ -63,20 +63,20 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_iam_account_password_policy"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if attr := block.GetAttribute("max_password_age"); attr == nil {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if attr := resourceBlock.GetAttribute("max_password_age"); attr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have a max password age set.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have a max password age set.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			} else if attr.Value().Type() == cty.Number {
 				value, _ := attr.Value().AsBigFloat().Float64()
 				if value > 90 {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has high password age.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has high password age.", resourceBlock.FullName())).
 							WithRange(attr.Range()).
 							WithAttributeAnnotation(attr).
 							WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws039.go
+++ b/internal/app/tfsec/rules/aws039.go
@@ -63,21 +63,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_iam_account_password_policy"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if attr := block.GetAttribute("minimum_password_length"); attr == nil {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if attr := resourceBlock.GetAttribute("minimum_password_length"); attr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have a minimum password length set.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have a minimum password length set.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			} else if attr.Value().Type() == cty.Number {
 				value, _ := attr.Value().AsBigFloat().Float64()
 				if value < 14 {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has a minimum password length which is less than 14 characters.", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has a minimum password length which is less than 14 characters.", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Warning),
 					)
 				}

--- a/internal/app/tfsec/rules/aws040.go
+++ b/internal/app/tfsec/rules/aws040.go
@@ -61,20 +61,20 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_iam_account_password_policy"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if attr := block.GetAttribute("require_symbols"); attr == nil {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if attr := resourceBlock.GetAttribute("require_symbols"); attr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not require a symbol in the password.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not require a symbol in the password.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			} else if attr.Value().Type() == cty.Bool {
 				if attr.Value().False() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least one symbol in the password.", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least one symbol in the password.", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Warning),
 					)
 				}

--- a/internal/app/tfsec/rules/aws041.go
+++ b/internal/app/tfsec/rules/aws041.go
@@ -61,20 +61,20 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_iam_account_password_policy"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if attr := block.GetAttribute("require_numbers"); attr == nil {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if attr := resourceBlock.GetAttribute("require_numbers"); attr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not require a number in the password.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not require a number in the password.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			} else if attr.Value().Type() == cty.Bool {
 				if attr.Value().False() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least one number in the password.", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least one number in the password.", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Warning),
 					)
 				}

--- a/internal/app/tfsec/rules/aws042.go
+++ b/internal/app/tfsec/rules/aws042.go
@@ -61,20 +61,20 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_iam_account_password_policy"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if attr := block.GetAttribute("require_lowercase_characters"); attr == nil {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if attr := resourceBlock.GetAttribute("require_lowercase_characters"); attr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not require a lowercase character in the password.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not require a lowercase character in the password.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			} else if attr.Value().Type() == cty.Bool {
 				if attr.Value().False() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least lowercase character in the password.", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least lowercase character in the password.", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Warning),
 					)
 				}

--- a/internal/app/tfsec/rules/aws043.go
+++ b/internal/app/tfsec/rules/aws043.go
@@ -62,20 +62,20 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_iam_account_password_policy"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if attr := block.GetAttribute("require_uppercase_characters"); attr == nil {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if attr := resourceBlock.GetAttribute("require_uppercase_characters"); attr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not require an uppercase character in the password.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not require an uppercase character in the password.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			} else if attr.Value().Type() == cty.Bool {
 				if attr.Value().False() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least one uppercase character in the password.", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' explicitly specifies not requiring at least one uppercase character in the password.", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Warning),
 					)
 				}

--- a/internal/app/tfsec/rules/aws044.go
+++ b/internal/app/tfsec/rules/aws044.go
@@ -55,20 +55,20 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"provider"},
 		RequiredLabels: []string{"aws"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if accessKeyAttribute := block.GetAttribute("access_key"); accessKeyAttribute != nil && accessKeyAttribute.Type() == cty.String {
+			if accessKeyAttribute := resourceBlock.GetAttribute("access_key"); accessKeyAttribute != nil && accessKeyAttribute.Type() == cty.String {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Provider '%s' has an access key specified.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Provider '%s' has an access key specified.", resourceBlock.FullName())).
 						WithRange(accessKeyAttribute.Range()).
 						WithAttributeAnnotation(accessKeyAttribute).
 						WithSeverity(severity.Error),
 				)
-			} else if secretKeyAttribute := block.GetAttribute("secret_key"); secretKeyAttribute != nil && secretKeyAttribute.Type() == cty.String {
+			} else if secretKeyAttribute := resourceBlock.GetAttribute("secret_key"); secretKeyAttribute != nil && secretKeyAttribute.Type() == cty.String {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Provider '%s' has a secret key specified.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Provider '%s' has a secret key specified.", resourceBlock.FullName())).
 						WithRange(secretKeyAttribute.Range()).
 						WithAttributeAnnotation(secretKeyAttribute).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws045.go
+++ b/internal/app/tfsec/rules/aws045.go
@@ -109,14 +109,14 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudfront_distribution"},
-		CheckFunc: func(set result.Set, block *block.Block, context *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
-			wafAclIdBlock := block.GetAttribute("web_acl_id")
+			wafAclIdBlock := resourceBlock.GetAttribute("web_acl_id")
 			if wafAclIdBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have a WAF in front of it.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have a WAF in front of it.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}

--- a/internal/app/tfsec/rules/aws046.go
+++ b/internal/app/tfsec/rules/aws046.go
@@ -67,9 +67,9 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"data"},
 		RequiredLabels: []string{"aws_iam_policy_document"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if statementBlocks := block.GetBlocks("statement"); statementBlocks != nil {
+			if statementBlocks := resourceBlock.GetBlocks("statement"); statementBlocks != nil {
 				for _, statementBlock := range statementBlocks {
 					if effect := statementBlock.GetAttribute("effect"); effect != nil {
 						if effect.Type() == cty.String && strings.ToLower(effect.Value().AsString()) == "deny" {
@@ -81,9 +81,9 @@ func init() {
 						for _, actionValue := range actionValues {
 							if actionValue.AsString() == "*" {
 								set.Add(
-									result.New().
-										WithDescription(fmt.Sprintf("Resource '%s' has a wildcard action specified.", block.FullName())).
-WithRange(statementBlock.Range()).
+									result.New(resourceBlock).
+										WithDescription(fmt.Sprintf("Resource '%s' has a wildcard action specified.", resourceBlock.FullName())).
+										WithRange(statementBlock.Range()).
 										WithSeverity(severity.Error),
 								)
 							}

--- a/internal/app/tfsec/rules/aws047.go
+++ b/internal/app/tfsec/rules/aws047.go
@@ -83,12 +83,12 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_sqs_queue_policy"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.GetAttribute("policy").Value().Type() != cty.String {
+			if resourceBlock.GetAttribute("policy").Value().Type() != cty.String {
 			}
 
-			rawJSON := []byte(block.GetAttribute("policy").Value().AsString())
+			rawJSON := []byte(resourceBlock.GetAttribute("policy").Value().AsString())
 			var policy struct {
 				Statement []struct {
 					Effect string `json:"Effect"`
@@ -100,9 +100,9 @@ func init() {
 				for _, statement := range policy.Statement {
 					if strings.ToLower(statement.Effect) == "allow" && (statement.Action == "*" || statement.Action == "sqs:*") {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("SQS policy '%s' has a wildcard action specified.", block.FullName())).
-								WithRange(block.Range()).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("SQS policy '%s' has a wildcard action specified.", resourceBlock.FullName())).
+								WithRange(resourceBlock.Range()).
 								WithSeverity(severity.Error),
 						)
 					}

--- a/internal/app/tfsec/rules/aws048.go
+++ b/internal/app/tfsec/rules/aws048.go
@@ -57,21 +57,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_efs_file_system"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			efsEnabledAttr := block.GetAttribute("encrypted")
+			efsEnabledAttr := resourceBlock.GetAttribute("encrypted")
 
 			if efsEnabledAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not specify if encryption should be used.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not specify if encryption should be used.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			} else if efsEnabledAttr.Type() == cty.Bool && efsEnabledAttr.Value().False() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' actively does not have encryption applied.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' actively does not have encryption applied.", resourceBlock.FullName())).
 						WithRange(efsEnabledAttr.Range()).
 						WithAttributeAnnotation(efsEnabledAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws049.go
+++ b/internal/app/tfsec/rules/aws049.go
@@ -64,11 +64,11 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_network_acl_rule"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			egressAttr := block.GetAttribute("egress")
-			actionAttr := block.GetAttribute("rule_action")
-			protoAttr := block.GetAttribute("protocol")
+			egressAttr := resourceBlock.GetAttribute("egress")
+			actionAttr := resourceBlock.GetAttribute("rule_action")
+			protoAttr := resourceBlock.GetAttribute("protocol")
 
 			if egressAttr.Type() == cty.Bool && egressAttr.Value().True() {
 			}
@@ -79,14 +79,14 @@ func init() {
 			if actionAttr.Value().AsString() != "allow" {
 			}
 
-			if cidrBlockAttr := block.GetAttribute("cidr_block"); cidrBlockAttr != nil {
+			if cidrBlockAttr := resourceBlock.GetAttribute("cidr_block"); cidrBlockAttr != nil {
 
 				if isOpenCidr(cidrBlockAttr) {
 					if protoAttr.Value().AsString() == "all" || protoAttr.Value().AsString() == "-1" {
 					} else {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' defines a Network ACL rule that allows specific ingress ports from anywhere.", block.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' defines a Network ACL rule that allows specific ingress ports from anywhere.", resourceBlock.FullName())).
 								WithRange(cidrBlockAttr.Range()).
 								WithSeverity(severity.Warning),
 						)
@@ -95,14 +95,14 @@ func init() {
 
 			}
 
-			if ipv6CidrBlockAttr := block.GetAttribute("ipv6_cidr_block"); ipv6CidrBlockAttr != nil {
+			if ipv6CidrBlockAttr := resourceBlock.GetAttribute("ipv6_cidr_block"); ipv6CidrBlockAttr != nil {
 
 				if isOpenCidr(ipv6CidrBlockAttr) {
 					if protoAttr.Value().AsString() == "all" || protoAttr.Value().AsString() == "-1" {
 					} else {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' defines a Network ACL rule that allows specific ingress ports from anywhere.", block.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' defines a Network ACL rule that allows specific ingress ports from anywhere.", resourceBlock.FullName())).
 								WithRange(ipv6CidrBlockAttr.Range()).
 								WithAttributeAnnotation(ipv6CidrBlockAttr).
 								WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws050.go
+++ b/internal/app/tfsec/rules/aws050.go
@@ -62,11 +62,11 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_network_acl_rule"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			egressAttr := block.GetAttribute("egress")
-			actionAttr := block.GetAttribute("rule_action")
-			protoAttr := block.GetAttribute("protocol")
+			egressAttr := resourceBlock.GetAttribute("egress")
+			actionAttr := resourceBlock.GetAttribute("rule_action")
+			protoAttr := resourceBlock.GetAttribute("protocol")
 
 			if egressAttr.Type() == cty.Bool && egressAttr.Value().True() {
 			}
@@ -77,13 +77,13 @@ func init() {
 			if actionAttr.Value().AsString() != "allow" {
 			}
 
-			if cidrBlockAttr := block.GetAttribute("cidr_block"); cidrBlockAttr != nil {
+			if cidrBlockAttr := resourceBlock.GetAttribute("cidr_block"); cidrBlockAttr != nil {
 
 				if isOpenCidr(cidrBlockAttr) {
 					if protoAttr.Value().AsString() == "all" || protoAttr.Value().AsString() == "-1" {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress Network ACL rule with ALL ports open.", block.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress Network ACL rule with ALL ports open.", resourceBlock.FullName())).
 								WithRange(cidrBlockAttr.Range()).
 								WithAttributeAnnotation(cidrBlockAttr).
 								WithSeverity(severity.Error),
@@ -94,13 +94,13 @@ func init() {
 
 			}
 
-			if ipv6CidrBlockAttr := block.GetAttribute("ipv6_cidr_block"); ipv6CidrBlockAttr != nil {
+			if ipv6CidrBlockAttr := resourceBlock.GetAttribute("ipv6_cidr_block"); ipv6CidrBlockAttr != nil {
 
 				if isOpenCidr(ipv6CidrBlockAttr) {
 					if protoAttr.Value().AsString() == "all" || protoAttr.Value().AsString() == "-1" {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress Network ACL rule with ALL ports open.", block.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress Network ACL rule with ALL ports open.", resourceBlock.FullName())).
 								WithRange(ipv6CidrBlockAttr.Range()).
 								WithAttributeAnnotation(ipv6CidrBlockAttr).
 								WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws051.go
+++ b/internal/app/tfsec/rules/aws051.go
@@ -56,31 +56,31 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_rds_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			kmsKeyIdAttr := block.GetAttribute("kms_key_id")
-			storageEncryptedattr := block.GetAttribute("storage_encrypted")
+			kmsKeyIdAttr := resourceBlock.GetAttribute("kms_key_id")
+			storageEncryptedattr := resourceBlock.GetAttribute("storage_encrypted")
 
 			if (kmsKeyIdAttr == nil || kmsKeyIdAttr.IsEmpty()) &&
 				(storageEncryptedattr == nil || storageEncryptedattr.IsFalse()) {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a disabled RDS Cluster encryption.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a disabled RDS Cluster encryption.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			} else if kmsKeyIdAttr.Equals("") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a disabled RDS Cluster encryption.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a disabled RDS Cluster encryption.", resourceBlock.FullName())).
 						WithRange(kmsKeyIdAttr.Range()).
 						WithAttributeAnnotation(kmsKeyIdAttr).
 						WithSeverity(severity.Error),
 				)
 			} else if storageEncryptedattr == nil || storageEncryptedattr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a enabled RDS Cluster encryption but not the required encrypted_storage.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a enabled RDS Cluster encryption but not the required encrypted_storage.", resourceBlock.FullName())).
 						WithRange(kmsKeyIdAttr.Range()).
 						WithAttributeAnnotation(kmsKeyIdAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws052.go
+++ b/internal/app/tfsec/rules/aws052.go
@@ -55,22 +55,22 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_db_instance"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("storage_encrypted") {
+			if resourceBlock.MissingChild("storage_encrypted") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has no storage encryption defined.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has no storage encryption defined.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
-			storageEncryptedAttr := block.GetAttribute("storage_encrypted")
+			storageEncryptedAttr := resourceBlock.GetAttribute("storage_encrypted")
 			if storageEncryptedAttr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has storage encrypted set to false", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has storage encrypted set to false", resourceBlock.FullName())).
 						WithRange(storageEncryptedAttr.Range()).
 						WithAttributeAnnotation(storageEncryptedAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws053.go
+++ b/internal/app/tfsec/rules/aws053.go
@@ -60,23 +60,23 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_rds_cluster_instance", "aws_db_instance"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.HasChild("performance_insights_enabled") && block.GetAttribute("performance_insights_enabled").IsTrue() {
-				if block.MissingChild("performance_insights_kms_key_id") {
+			if resourceBlock.HasChild("performance_insights_enabled") && resourceBlock.GetAttribute("performance_insights_enabled").IsTrue() {
+				if resourceBlock.MissingChild("performance_insights_kms_key_id") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines Performance Insights without encryption key specified.", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines Performance Insights without encryption key specified.", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Error),
 					)
 					return
 				}
 
-				if keyAttr := block.GetAttribute("performance_insights_kms_key_id"); keyAttr.IsEmpty() {
+				if keyAttr := resourceBlock.GetAttribute("performance_insights_kms_key_id"); keyAttr.IsEmpty() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines Performance Insights without encryption key specified.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines Performance Insights without encryption key specified.", resourceBlock.FullName())).
 							WithRange(keyAttr.Range()).
 							WithAttributeAnnotation(keyAttr).
 							WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws057.go
+++ b/internal/app/tfsec/rules/aws057.go
@@ -90,25 +90,25 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticsearch_domain"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("log_publishing_options") {
+			if resourceBlock.MissingChild("log_publishing_options") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not configure logging at rest on the domain.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not configure logging at rest on the domain.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
 			}
 
-			logOptions := block.GetBlocks("log_publishing_options")
+			logOptions := resourceBlock.GetBlocks("log_publishing_options")
 			for _, logOption := range logOptions {
 				enabledAttr := logOption.GetAttribute("enabled")
 				if enabledAttr != nil && enabledAttr.IsFalse() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' explicitly disables logging on the domain.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' explicitly disables logging on the domain.", resourceBlock.FullName())).
 							WithRange(enabledAttr.Range()).
 							WithAttributeAnnotation(enabledAttr).
 							WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws058.go
+++ b/internal/app/tfsec/rules/aws058.go
@@ -62,15 +62,15 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_lambda_permission"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.HasChild("principal") {
-				if block.GetAttribute("principal").EndsWith("amazonaws.com") {
-					if block.MissingChild("source_arn") {
+			if resourceBlock.HasChild("principal") {
+				if resourceBlock.GetAttribute("principal").EndsWith("amazonaws.com") {
+					if resourceBlock.MissingChild("source_arn") {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' missing source ARN but has *.amazonaws.com Principal.", block.FullName())).
-								WithRange(block.Range()).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' missing source ARN but has *.amazonaws.com Principal.", resourceBlock.FullName())).
+								WithRange(resourceBlock.Range()).
 								WithSeverity(severity.Error),
 						)
 					}

--- a/internal/app/tfsec/rules/aws059.go
+++ b/internal/app/tfsec/rules/aws059.go
@@ -94,24 +94,24 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_athena_database", "aws_athena_workgroup"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			blockName := block.FullName()
+			blockName := resourceBlock.FullName()
 
-			if strings.EqualFold(block.TypeLabel(), "aws_athena_workgroup") {
-				if block.HasChild("configuration") && block.GetBlock("configuration").
+			if strings.EqualFold(resourceBlock.TypeLabel(), "aws_athena_workgroup") {
+				if resourceBlock.HasChild("configuration") && resourceBlock.GetBlock("configuration").
 					HasChild("result_configuration") {
-					block = block.GetBlock("configuration").GetBlock("result_configuration")
+					resourceBlock = resourceBlock.GetBlock("configuration").GetBlock("result_configuration")
 				} else {
 					return
 				}
 			}
 
-			if block.MissingChild("encryption_configuration") {
+			if resourceBlock.MissingChild("encryption_configuration") {
 				set.Add(
-					result.New().
+					result.New(resourceBlock).
 						WithDescription(fmt.Sprintf("Resource '%s' missing encryption configuration block.", blockName)).
-						WithRange(block.Range()).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/aws060.go
+++ b/internal/app/tfsec/rules/aws060.go
@@ -86,24 +86,24 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_athena_workgroup"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("configuration") {
+			if resourceBlock.MissingChild("configuration") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is missing the configuration block.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is missing the configuration block.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
-			configBlock := block.GetBlock("configuration")
+			configBlock := resourceBlock.GetBlock("configuration")
 			if configBlock.HasChild("enforce_workgroup_configuration") &&
 				configBlock.GetAttribute("enforce_workgroup_configuration").IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has enforce_workgroup_configuration set to false.", block.FullName())).
-WithRange(configBlock.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has enforce_workgroup_configuration set to false.", resourceBlock.FullName())).
+						WithRange(configBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/aws061.go
+++ b/internal/app/tfsec/rules/aws061.go
@@ -77,13 +77,13 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_apigatewayv2_stage", "aws_api_gateway_stage"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("access_log_settings") {
+			if resourceBlock.MissingChild("access_log_settings") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is missing access log settings block.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is missing access log settings block.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/aws062.go
+++ b/internal/app/tfsec/rules/aws062.go
@@ -81,7 +81,7 @@ func init() {
 			if userDataAttr.Contains("AWS_ACCESS_KEY_ID", block.IgnoreCase) &&
 				userDataAttr.RegexMatches("(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}") {
 				set.Add(
-					result.New().
+					result.New(resourceBlock).
 						WithDescription(fmt.Sprintf("Resource '%s' has userdata with access key id defined.", resourceBlock.FullName())).
 						WithRange(userDataAttr.Range()).
 						WithAttributeAnnotation(userDataAttr).
@@ -92,7 +92,7 @@ func init() {
 			if userDataAttr.Contains("AWS_SECRET_ACCESS_KEY", block.IgnoreCase) &&
 				userDataAttr.RegexMatches("(?i)aws_secre.+[=:]\\s{0,}[A-Za-z0-9\\/+=]{40}.?") {
 				set.Add(
-					result.New().
+					result.New(resourceBlock).
 						WithDescription(fmt.Sprintf("Resource '%s' has userdata with access secret key defined.", resourceBlock.FullName())).
 						WithRange(userDataAttr.Range()).
 						WithAttributeAnnotation(userDataAttr).

--- a/internal/app/tfsec/rules/aws063.go
+++ b/internal/app/tfsec/rules/aws063.go
@@ -71,21 +71,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudtrail"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if block.MissingChild("is_multi_region_trail") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.MissingChild("is_multi_region_trail") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not set multi region trail config.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not set multi region trail config.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}
 
-			multiRegionAttr := block.GetAttribute("is_multi_region_trail")
+			multiRegionAttr := resourceBlock.GetAttribute("is_multi_region_trail")
 			if multiRegionAttr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not enable multi region trail.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not enable multi region trail.", resourceBlock.FullName())).
 						WithRange(multiRegionAttr.Range()).
 						WithAttributeAnnotation(multiRegionAttr).
 						WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws064.go
+++ b/internal/app/tfsec/rules/aws064.go
@@ -74,21 +74,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudtrail"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if block.MissingChild("enable_log_file_validation") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.MissingChild("enable_log_file_validation") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not enable log file validation.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not enable log file validation.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}
 
-			logFileValidationAttr := block.GetAttribute("enable_log_file_validation")
+			logFileValidationAttr := resourceBlock.GetAttribute("enable_log_file_validation")
 			if logFileValidationAttr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not enable log file validation.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not enable log file validation.", resourceBlock.FullName())).
 						WithRange(logFileValidationAttr.Range()).
 						WithAttributeAnnotation(logFileValidationAttr).
 						WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws065.go
+++ b/internal/app/tfsec/rules/aws065.go
@@ -75,23 +75,23 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudtrail"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("kms_key_id") {
+			if resourceBlock.MissingChild("kms_key_id") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have a kms_key_id set.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have a kms_key_id set.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
 			}
 
-			kmsKeyIdAttr := block.GetAttribute("kms_key_id")
+			kmsKeyIdAttr := resourceBlock.GetAttribute("kms_key_id")
 			if kmsKeyIdAttr.IsEmpty() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has a kms_key_id but it is not set.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has a kms_key_id but it is not set.", resourceBlock.FullName())).
 						WithRange(kmsKeyIdAttr.Range()).
 						WithAttributeAnnotation(kmsKeyIdAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws066.go
+++ b/internal/app/tfsec/rules/aws066.go
@@ -69,23 +69,23 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_eks_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("encryption_config") {
+			if resourceBlock.MissingChild("encryption_config") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has no encryptionConfigBlock block", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has no encryptionConfigBlock block", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
 			}
 
-			encryptionConfigBlock := block.GetBlock("encryption_config")
+			encryptionConfigBlock := resourceBlock.GetBlock("encryption_config")
 			if encryptionConfigBlock.MissingChild("resources") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has encryptionConfigBlock block with no resourcesAttr attribute specified", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has encryptionConfigBlock block with no resourcesAttr attribute specified", resourceBlock.FullName())).
 						WithRange(encryptionConfigBlock.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -95,8 +95,8 @@ func init() {
 			resourcesAttr := encryptionConfigBlock.GetAttribute("resources")
 			if !resourcesAttr.Contains("secrets") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not include secrets in encrypted resources", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not include secrets in encrypted resources", resourceBlock.FullName())).
 						WithRange(resourcesAttr.Range()).
 						WithAttributeAnnotation(resourcesAttr).
 						WithSeverity(severity.Error),
@@ -105,8 +105,8 @@ func init() {
 
 			if encryptionConfigBlock.MissingChild("provider") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has encryptionConfigBlock block with no provider block specified", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has encryptionConfigBlock block with no provider block specified", resourceBlock.FullName())).
 						WithRange(encryptionConfigBlock.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -116,8 +116,8 @@ func init() {
 			providerBlock := encryptionConfigBlock.GetBlock("provider")
 			if providerBlock.MissingChild("key_arn") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has encryptionConfigBlock block with provider block specified missing key arn", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has encryptionConfigBlock block with provider block specified missing key arn", resourceBlock.FullName())).
 						WithRange(encryptionConfigBlock.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -127,8 +127,8 @@ func init() {
 			keyArnAttr := providerBlock.GetAttribute("key_arn")
 			if keyArnAttr.IsEmpty() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has encryptionConfigBlock block with provider block specified but key_arn is empty", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has encryptionConfigBlock block with provider block specified but key_arn is empty", resourceBlock.FullName())).
 						WithRange(keyArnAttr.Range()).
 						WithAttributeAnnotation(keyArnAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws067.go
+++ b/internal/app/tfsec/rules/aws067.go
@@ -77,26 +77,26 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_eks_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			controlPlaneLogging := []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}
 
-			if block.MissingChild("enabled_cluster_log_types") {
+			if resourceBlock.MissingChild("enabled_cluster_log_types") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' missing the enabled_cluster_log_types attribute to enable control plane logging", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' missing the enabled_cluster_log_types attribute to enable control plane logging", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
 			}
 
-			configuredLoggingAttr := block.GetAttribute("enabled_cluster_log_types")
+			configuredLoggingAttr := resourceBlock.GetAttribute("enabled_cluster_log_types")
 			for _, logType := range controlPlaneLogging {
 				if !configuredLoggingAttr.Contains(logType) {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' is missing the control plane log type '%s'", block.FullName(), logType)).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' is missing the control plane log type '%s'", resourceBlock.FullName(), logType)).
 							WithRange(configuredLoggingAttr.Range()).
 							WithAttributeAnnotation(configuredLoggingAttr).
 							WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws068.go
+++ b/internal/app/tfsec/rules/aws068.go
@@ -66,22 +66,22 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_eks_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("vpc_config") {
+			if resourceBlock.MissingChild("vpc_config") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has no vpc_config block specified so default public access cidrs is set", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has no vpc_config block specified so default public access cidrs is set", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
-			vpcConfig := block.GetBlock("vpc_config")
+			vpcConfig := resourceBlock.GetBlock("vpc_config")
 			if vpcConfig.MissingChild("public_access_cidrs") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is using default public access cidrs in the vpc config", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is using default public access cidrs in the vpc config", resourceBlock.FullName())).
 						WithRange(vpcConfig.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -90,8 +90,8 @@ func init() {
 			publicAccessCidrsAttr := vpcConfig.GetAttribute("public_access_cidrs")
 			if isOpenCidr(publicAccessCidrsAttr) {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has public access cidr explicitly set to wide open", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has public access cidr explicitly set to wide open", resourceBlock.FullName())).
 						WithRange(publicAccessCidrsAttr.Range()).
 						WithAttributeAnnotation(publicAccessCidrsAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws069.go
+++ b/internal/app/tfsec/rules/aws069.go
@@ -66,22 +66,22 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_eks_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("vpc_config") {
+			if resourceBlock.MissingChild("vpc_config") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has no vpc_config block specified so default public access is enabled", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has no vpc_config block specified so default public access is enabled", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
-			vpcConfig := block.GetBlock("vpc_config")
+			vpcConfig := resourceBlock.GetBlock("vpc_config")
 			if vpcConfig.MissingChild("endpoint_public_access") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is using default public access in the vpc config", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is using default public access in the vpc config", resourceBlock.FullName())).
 						WithRange(vpcConfig.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -90,8 +90,8 @@ func init() {
 			publicAccessEnabledAttr := vpcConfig.GetAttribute("endpoint_public_access")
 			if publicAccessEnabledAttr.IsTrue() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has public access is explicitly set to enabled", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has public access is explicitly set to enabled", resourceBlock.FullName())).
 						WithRange(publicAccessEnabledAttr.Range()).
 						WithAttributeAnnotation(publicAccessEnabledAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws070.go
+++ b/internal/app/tfsec/rules/aws070.go
@@ -64,8 +64,8 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticsearch_domain"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			logPublishingOptions := block.GetBlocks("log_publishing_options")
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			logPublishingOptions := resourceBlock.GetBlocks("log_publishing_options")
 			if len(logPublishingOptions) > 0 {
 				auditLogFound := false
 				for _, logPublishingOption := range logPublishingOptions {
@@ -79,9 +79,9 @@ func init() {
 
 				if !auditLogFound {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' is missing 'AUDIT_LOGS` in one of the `log_publishing_options`-`log_type` attributes so audit log is not enabled", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' is missing 'AUDIT_LOGS` in one of the `log_publishing_options`-`log_type` attributes so audit log is not enabled", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Error),
 					)
 				}

--- a/internal/app/tfsec/rules/aws071.go
+++ b/internal/app/tfsec/rules/aws071.go
@@ -59,13 +59,13 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudfront_distribution"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("logging_config") {
+			if resourceBlock.MissingChild("logging_config") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have Access Logging configured", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have Access Logging configured", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/aws072.go
+++ b/internal/app/tfsec/rules/aws072.go
@@ -88,24 +88,24 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudfront_distribution"},
-		CheckFunc: func(set result.Set, b *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			defaultCacheBlock := b.GetBlock("default_cache_behavior")
+			defaultCacheBlock := resourceBlock.GetBlock("default_cache_behavior")
 			if defaultCacheBlock.GetAttribute("viewer_protocol_policy").Equals("allow-all", block.IgnoreCase) {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not use HTTPS in Viewer Protocol Policy", b.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not use HTTPS in Viewer Protocol Policy", resourceBlock.FullName())).
 						WithRange(defaultCacheBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
-			orderedCacheBlocks := b.GetBlocks("ordered_cache_behavior")
+			orderedCacheBlocks := resourceBlock.GetBlocks("ordered_cache_behavior")
 			for _, orderedCacheBlock := range orderedCacheBlocks {
 				if orderedCacheBlock.GetAttribute("viewer_protocol_policy").Equals("allow-all", block.IgnoreCase) {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' does not use HTTPS in Viewer Protocol Policy", b.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' does not use HTTPS in Viewer Protocol Policy", resourceBlock.FullName())).
 							WithRange(orderedCacheBlock.Range()).
 							WithSeverity(severity.Error),
 					)

--- a/internal/app/tfsec/rules/aws073.go
+++ b/internal/app/tfsec/rules/aws073.go
@@ -61,22 +61,22 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_s3_bucket_public_access_block"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("ignore_public_acls") {
+			if resourceBlock.MissingChild("ignore_public_acls") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not specify ignore_public_acls, defaults to false", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not specify ignore_public_acls, defaults to false", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
-			attr := block.GetAttribute("ignore_public_acls")
+			attr := resourceBlock.GetAttribute("ignore_public_acls")
 			if attr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' sets ignore_public_acls explicitly to false", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' sets ignore_public_acls explicitly to false", resourceBlock.FullName())).
 						WithRange(attr.Range()).
 						WithAttributeAnnotation(attr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws074.go
+++ b/internal/app/tfsec/rules/aws074.go
@@ -61,21 +61,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_s3_bucket_public_access_block"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if block.MissingChild("block_public_acls") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.MissingChild("block_public_acls") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not specify block_public_acls, defaults to false", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not specify block_public_acls, defaults to false", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
-			attr := block.GetAttribute("block_public_acls")
+			attr := resourceBlock.GetAttribute("block_public_acls")
 			if attr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' sets block_public_acls explicitly to false", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' sets block_public_acls explicitly to false", resourceBlock.FullName())).
 						WithRange(attr.Range()).
 						WithAttributeAnnotation(attr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws075.go
+++ b/internal/app/tfsec/rules/aws075.go
@@ -61,21 +61,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_s3_bucket_public_access_block"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if block.MissingChild("restrict_public_buckets") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.MissingChild("restrict_public_buckets") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not specify restrict_public_buckets, defaults to false", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not specify restrict_public_buckets, defaults to false", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
-			attr := block.GetAttribute("restrict_public_buckets")
+			attr := resourceBlock.GetAttribute("restrict_public_buckets")
 			if attr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' sets restrict_public_buckets explicitly to false", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' sets restrict_public_buckets explicitly to false", resourceBlock.FullName())).
 						WithRange(attr.Range()).
 						WithAttributeAnnotation(attr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws076.go
+++ b/internal/app/tfsec/rules/aws076.go
@@ -61,21 +61,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_s3_bucket_public_access_block"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if block.MissingChild("block_public_policy") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.MissingChild("block_public_policy") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not specify block_public_policy, defaults to false", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not specify block_public_policy, defaults to false", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
-			attr := block.GetAttribute("block_public_policy")
+			attr := resourceBlock.GetAttribute("block_public_policy")
 			if attr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' sets block_public_policy explicitly to false", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' sets block_public_policy explicitly to false", resourceBlock.FullName())).
 						WithRange(attr.Range()).
 						WithAttributeAnnotation(attr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws077.go
+++ b/internal/app/tfsec/rules/aws077.go
@@ -58,23 +58,23 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_s3_bucket"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("versioning") {
+			if resourceBlock.MissingChild("versioning") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have versioning enabled", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have versioning enabled", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
-			versioningBlock := block.GetBlock("versioning")
+			versioningBlock := resourceBlock.GetBlock("versioning")
 			if versioningBlock.HasChild("enabled") && versioningBlock.GetAttribute("enabled").IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has versioning block but is disabled", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has versioning block but is disabled", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/aws078.go
+++ b/internal/app/tfsec/rules/aws078.go
@@ -65,14 +65,14 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_ecr_repository"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			imageTagMutabilityAttr := block.GetAttribute("image_tag_mutability")
+			imageTagMutabilityAttr := resourceBlock.GetAttribute("image_tag_mutability")
 			if imageTagMutabilityAttr == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is missing `image_tag_mutability` attribute - it is required to make ecr image tag immutable.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is missing `image_tag_mutability` attribute - it is required to make ecr image tag immutable.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
@@ -80,8 +80,8 @@ func init() {
 
 			if !imageTagMutabilityAttr.Equals("IMMUTABLE") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has `image_tag_mutability` attribute  not set to `IMMUTABLE`", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has `image_tag_mutability` attribute  not set to `IMMUTABLE`", resourceBlock.FullName())).
 						WithRange(imageTagMutabilityAttr.Range()).
 						WithAttributeAnnotation(imageTagMutabilityAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws079.go
+++ b/internal/app/tfsec/rules/aws079.go
@@ -60,14 +60,14 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_instance"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			metaDataOptions := block.GetBlock("metadata_options")
+			metaDataOptions := resourceBlock.GetBlock("metadata_options")
 			if metaDataOptions == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is missing `metadata_options` block - it is required with `http_tokens` set to `required` to make Instance Metadata Service more secure.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is missing `metadata_options` block - it is required with `http_tokens` set to `required` to make Instance Metadata Service more secure.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
@@ -85,8 +85,8 @@ func init() {
 			if httpTokensAttr != nil {
 				if !httpTokensAttr.Equals("required") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' `metadata_options` `http_tokens` attribute - should be set to `required` to make Instance Metadata Service more secure.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' `metadata_options` `http_tokens` attribute - should be set to `required` to make Instance Metadata Service more secure.", resourceBlock.FullName())).
 							WithRange(httpTokensAttr.Range()).
 							WithSeverity(severity.Error),
 					)

--- a/internal/app/tfsec/rules/aws080.go
+++ b/internal/app/tfsec/rules/aws080.go
@@ -104,10 +104,10 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_codebuild_project"},
-		CheckFunc: func(set result.Set, b *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			blocks := b.GetBlocks("secondary_artifacts")
-			if artifact := b.GetBlock("artifacts"); artifact != nil {
+			blocks := resourceBlock.GetBlocks("secondary_artifacts")
+			if artifact := resourceBlock.GetBlock("artifacts"); artifact != nil {
 				blocks = append(blocks, artifact)
 			}
 
@@ -117,16 +117,16 @@ func init() {
 
 					if artifactTypeAttr.Equals("NO_ARTIFACTS", block.IgnoreCase) {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("CodeBuild project '%s' is configured to disable artifact encryption while no artifacts are produced", b.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("CodeBuild project '%s' is configured to disable artifact encryption while no artifacts are produced", resourceBlock.FullName())).
 								WithRange(artifactBlock.Range()).
 								WithAttributeAnnotation(artifactTypeAttr).
 								WithSeverity(severity.Warning),
 						)
 					} else {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("CodeBuild project '%s' does not encrypt produced artifacts", b.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("CodeBuild project '%s' does not encrypt produced artifacts", resourceBlock.FullName())).
 								WithRange(artifactBlock.Range()).
 								WithAttributeAnnotation(encryptionDisabledAttr).
 								WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws081.go
+++ b/internal/app/tfsec/rules/aws081.go
@@ -74,21 +74,21 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_dax_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("server_side_encryption") {
-				res := result.New().
-					WithDescription(fmt.Sprintf("DAX cluster '%s' does not have server side encryption configured. By default it is disabled.", block.FullName())).
-					WithRange(block.Range()).
+			if resourceBlock.MissingChild("server_side_encryption") {
+				res := result.New(resourceBlock).
+					WithDescription(fmt.Sprintf("DAX cluster '%s' does not have server side encryption configured. By default it is disabled.", resourceBlock.FullName())).
+					WithRange(resourceBlock.Range()).
 					WithSeverity(severity.Error)
 				set.Add(res)
 				return
 			}
 
-			sseBlock := block.GetBlock("server_side_encryption")
+			sseBlock := resourceBlock.GetBlock("server_side_encryption")
 			if sseBlock.MissingChild("enabled") {
-				res := result.New().
-					WithDescription(fmt.Sprintf("DAX cluster '%s' server side encryption block is empty. By default SSE is disabled.", block.FullName())).
+				res := result.New(resourceBlock).
+					WithDescription(fmt.Sprintf("DAX cluster '%s' server side encryption block is empty. By default SSE is disabled.", resourceBlock.FullName())).
 					WithRange(sseBlock.Range()).
 					WithSeverity(severity.Error)
 				set.Add(res)
@@ -96,8 +96,8 @@ func init() {
 			}
 
 			if sseEnabledAttr := sseBlock.GetAttribute("enabled"); sseEnabledAttr.IsFalse() {
-				res := result.New().
-					WithDescription(fmt.Sprintf("DAX cluster '%s' has disabled server side encryption", block.FullName())).
+				res := result.New(resourceBlock).
+					WithDescription(fmt.Sprintf("DAX cluster '%s' has disabled server side encryption", resourceBlock.FullName())).
 					WithRange(sseEnabledAttr.Range()).
 					WithAttributeAnnotation(sseEnabledAttr).
 					WithSeverity(severity.Error)

--- a/internal/app/tfsec/rules/aws082.go
+++ b/internal/app/tfsec/rules/aws082.go
@@ -53,11 +53,11 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_default_vpc"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			set.Add(
-				result.New().
-					WithDescription(fmt.Sprintf("Resource '%s' should not exist", block.FullName())).
-					WithRange(block.Range()).
+				result.New(resourceBlock).
+					WithDescription(fmt.Sprintf("Resource '%s' should not exist", resourceBlock.FullName())).
+					WithRange(resourceBlock.Range()).
 					WithSeverity(severity.Error),
 			)
 		},

--- a/internal/app/tfsec/rules/aws083.go
+++ b/internal/app/tfsec/rules/aws083.go
@@ -75,23 +75,23 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_alb", "aws_lb"},
-		CheckFunc: func(set result.Set, b *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if b.GetAttribute("load_balancer_type").Equals("application", block.IgnoreCase) {
-				if b.MissingChild("drop_invalid_header_fields") {
+			if resourceBlock.GetAttribute("load_balancer_type").Equals("application", block.IgnoreCase) {
+				if resourceBlock.MissingChild("drop_invalid_header_fields") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' does not drop invalid header fields", b.FullName())).
-							WithRange(b.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' does not drop invalid header fields", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Error),
 					)
 				}
 
-				attr := b.GetAttribute("drop_invalid_header_fields")
+				attr := resourceBlock.GetAttribute("drop_invalid_header_fields")
 				if attr.IsFalse() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' sets the drop_invalid_header_fields to false", b.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' sets the drop_invalid_header_fields to false", resourceBlock.FullName())).
 							WithRange(attr.Range()).
 							WithAttributeAnnotation(attr).
 							WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws084.go
+++ b/internal/app/tfsec/rules/aws084.go
@@ -75,20 +75,20 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_workspaces_workspace"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("root_volume_encryption_enabled") {
+			if resourceBlock.MissingChild("root_volume_encryption_enabled") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have root volume encryption enables", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have root volume encryption enables", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			} else {
-				attr := block.GetAttribute("root_volume_encryption_enabled")
+				attr := resourceBlock.GetAttribute("root_volume_encryption_enabled")
 				if attr.IsFalse() {
-					set.Add(result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has the root volume encyption set to false", block.FullName())).
+					set.Add(result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has the root volume encyption set to false", resourceBlock.FullName())).
 						WithRange(attr.Range()).
 						WithAttributeAnnotation(attr).
 						WithSeverity(severity.Error),
@@ -96,18 +96,18 @@ func init() {
 				}
 			}
 
-			if block.MissingChild("user_volume_encryption_enabled") {
-				set.Add(result.New().
-					WithDescription(fmt.Sprintf("Resource '%s' should have user volume encryption enables", block.FullName())).
-					WithRange(block.Range()).
+			if resourceBlock.MissingChild("user_volume_encryption_enabled") {
+				set.Add(result.New(resourceBlock).
+					WithDescription(fmt.Sprintf("Resource '%s' should have user volume encryption enables", resourceBlock.FullName())).
+					WithRange(resourceBlock.Range()).
 					WithSeverity(severity.Error),
 				)
 			} else {
-				attr := block.GetAttribute("user_volume_encryption_enabled")
+				attr := resourceBlock.GetAttribute("user_volume_encryption_enabled")
 				if attr.IsFalse() {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has the user volume encyption set to false", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has the user volume encyption set to false", resourceBlock.FullName())).
 							WithRange(attr.Range()).
 							WithAttributeAnnotation(attr).
 							WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws085.go
+++ b/internal/app/tfsec/rules/aws085.go
@@ -65,23 +65,23 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_config_configuration_aggregator"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			aggBlock := block.GetFirstMatchingBlock("account_aggregation_source", "organization_aggregation_source")
+			aggBlock := resourceBlock.GetFirstMatchingBlock("account_aggregation_source", "organization_aggregation_source")
 			if aggBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have account aggregation sources set", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have account aggregation sources set", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 
 			if aggBlock.MissingChild("all_regions") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have account aggregation sources to all regions", block.FullName())).
-WithRange(aggBlock.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have account aggregation sources to all regions", resourceBlock.FullName())).
+						WithRange(aggBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}
@@ -89,8 +89,8 @@ WithRange(aggBlock.Range()).
 			allRegionsAttr := aggBlock.GetAttribute("all_regions")
 			if allRegionsAttr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has all_regions set to false", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has all_regions set to false", resourceBlock.FullName())).
 						WithRange(allRegionsAttr.Range()).
 						WithAttributeAnnotation(allRegionsAttr).
 						WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws086.go
+++ b/internal/app/tfsec/rules/aws086.go
@@ -77,31 +77,31 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_dynamodb_table"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("point_in_time_recovery") {
+			if resourceBlock.MissingChild("point_in_time_recovery") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' doesn't have point in time recovery", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' doesn't have point in time recovery", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}
 
-			poitBlock := block.GetBlock("point_in_time_recovery")
+			poitBlock := resourceBlock.GetBlock("point_in_time_recovery")
 			if poitBlock.MissingChild("enabled") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' doesn't have point in time recovery enabled", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' doesn't have point in time recovery enabled", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}
 			enabledAttr := poitBlock.GetAttribute("enabled")
 			if enabledAttr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' doesn't have point in time recovery enabled", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' doesn't have point in time recovery enabled", resourceBlock.FullName())).
 						WithRange(enabledAttr.Range()).
 						WithAttributeAnnotation(enabledAttr).
 						WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws087.go
+++ b/internal/app/tfsec/rules/aws087.go
@@ -67,12 +67,12 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_redshift_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if block.MissingChild("cluster_subnet_group_name") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.MissingChild("cluster_subnet_group_name") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is being deployed outside of a VPC", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is being deployed outside of a VPC", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/aws088.go
+++ b/internal/app/tfsec/rules/aws088.go
@@ -67,24 +67,24 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_elasticache_cluster"},
-		CheckFunc: func(set result.Set, b *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			engineAttr := b.GetAttribute("engine")
-			if engineAttr.Equals("redis", block.IgnoreCase) && !b.GetAttribute("node_type").Equals("cache.t1.micro") {
-				snapshotRetentionAttr := b.GetAttribute("snapshot_retention_limit")
+			engineAttr := resourceBlock.GetAttribute("engine")
+			if engineAttr.Equals("redis", block.IgnoreCase) && !resourceBlock.GetAttribute("node_type").Equals("cache.t1.micro") {
+				snapshotRetentionAttr := resourceBlock.GetAttribute("snapshot_retention_limit")
 				if snapshotRetentionAttr == nil {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' should have snapshot retention specified", b.FullName())).
-							WithRange(b.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' should have snapshot retention specified", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Warning),
 					)
 				}
 
 				if snapshotRetentionAttr.Equals(0) {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has snapshot retention set to 0", b.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has snapshot retention set to 0", resourceBlock.FullName())).
 							WithRange(snapshotRetentionAttr.Range()).
 							WithAttributeAnnotation(snapshotRetentionAttr).
 							WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws089.go
+++ b/internal/app/tfsec/rules/aws089.go
@@ -56,12 +56,12 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_cloudwatch_log_group"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if block.MissingChild("kms_key_id") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.MissingChild("kms_key_id") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is only using default encryption", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is only using default encryption", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Info),
 				)
 			}

--- a/internal/app/tfsec/rules/aws090.go
+++ b/internal/app/tfsec/rules/aws090.go
@@ -66,7 +66,7 @@ func init() {
 					if valueAttr := setting.GetAttribute("value"); valueAttr != nil {
 						if !valueAttr.Equals("enabled", block.IgnoreCase) {
 							set.Add(
-								result.New().
+								result.New(resourceBlock).
 									WithDescription(fmt.Sprintf("Resource '%s' has containerInsights set to disabled", resourceBlock.FullName())).
 									WithRange(setting.Range()).
 									WithAttributeAnnotation(valueAttr).
@@ -78,7 +78,7 @@ func init() {
 				}
 			}
 			set.Add(
-				result.New().
+				result.New(resourceBlock).
 					WithDescription(fmt.Sprintf("Resoure '%s' does not have codeInsights enabled", resourceBlock.FullName())).
 					WithRange(resourceBlock.Range()).
 					WithSeverity(severity.Info),

--- a/internal/app/tfsec/rules/aws091.go
+++ b/internal/app/tfsec/rules/aws091.go
@@ -94,26 +94,26 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_rds_cluster", "aws_db_instance"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if block.HasChild("replicate_source_db") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.HasChild("replicate_source_db") {
 				return
 			}
 
-			if block.MissingChild("backup_retention_period") {
+			if resourceBlock.MissingChild("backup_retention_period") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have backup retention explicitly set", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have backup retention explicitly set", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Info),
 				)
 				return
 			}
 
-			retentionAttr := block.GetAttribute("backup_retention_period")
+			retentionAttr := resourceBlock.GetAttribute("backup_retention_period")
 			if retentionAttr.LessThanOrEqualTo(1) {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has backup retention period set to a low value", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has backup retention period set to a low value", resourceBlock.FullName())).
 						WithRange(retentionAttr.Range()).
 						WithAttributeAnnotation(retentionAttr).
 						WithSeverity(severity.Info),

--- a/internal/app/tfsec/rules/aws092.go
+++ b/internal/app/tfsec/rules/aws092.go
@@ -96,23 +96,23 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_dynamodb_table"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("server_side_encryption") {
+			if resourceBlock.MissingChild("server_side_encryption") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is not using KMS CMK for encryption", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is not using KMS CMK for encryption", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Info),
 				)
 			}
 
-			sseBlock := block.GetBlock("server_side_encryption")
+			sseBlock := resourceBlock.GetBlock("server_side_encryption")
 			enabledAttr := sseBlock.GetAttribute("enabled")
 			if enabledAttr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has server side encryption configured but disabled", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has server side encryption configured but disabled", resourceBlock.FullName())).
 						WithRange(enabledAttr.Range()).
 						WithAttributeAnnotation(enabledAttr).
 						WithSeverity(severity.Info),
@@ -123,8 +123,8 @@ func init() {
 				keyIdAttr := sseBlock.GetAttribute("kms_key_arn")
 				if keyIdAttr.Equals("alias/aws/dynamodb") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has KMS encryption configured but is using the default aws key", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has KMS encryption configured but is using the default aws key", resourceBlock.FullName())).
 							WithRange(keyIdAttr.Range()).
 							WithAttributeAnnotation(keyIdAttr).
 							WithSeverity(severity.Info),

--- a/internal/app/tfsec/rules/aws093.go
+++ b/internal/app/tfsec/rules/aws093.go
@@ -73,32 +73,32 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_ecr_repository"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("encryption_configuration") {
+			if resourceBlock.MissingChild("encryption_configuration") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have CMK encryption configured", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have CMK encryption configured", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Info),
 				)
 			}
 
-			encBlock := block.GetBlock("encryption_configuration")
+			encBlock := resourceBlock.GetBlock("encryption_configuration")
 			if encBlock.MissingChild("kms_key") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' configures encryption without using CMK", block.FullName())).
-WithRange(encBlock.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' configures encryption without using CMK", resourceBlock.FullName())).
+						WithRange(encBlock.Range()).
 						WithSeverity(severity.Info),
 				)
 			}
 
 			if encBlock.MissingChild("encryption_type") || encBlock.GetAttribute("encryption_type").Equals("AES256") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have the encryption type set to KMS", block.FullName())).
-WithRange(encBlock.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have the encryption type set to KMS", resourceBlock.FullName())).
+						WithRange(encBlock.Range()).
 						WithSeverity(severity.Info),
 				)
 			}

--- a/internal/app/tfsec/rules/aws094.go
+++ b/internal/app/tfsec/rules/aws094.go
@@ -69,31 +69,31 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_redshift_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("encrypted") {
+			if resourceBlock.MissingChild("encrypted") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have encryption enabled", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have encryption enabled", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}
 
-			if block.MissingChild("kms_key_id") {
+			if resourceBlock.MissingChild("kms_key_id") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have a customer managed key specified", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have a customer managed key specified", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}
 
-			encryptedAttr := block.GetAttribute("encrypted")
+			encryptedAttr := resourceBlock.GetAttribute("encrypted")
 			if encryptedAttr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' has encryption explicitly dissabled", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' has encryption explicitly dissabled", resourceBlock.FullName())).
 						WithRange(encryptedAttr.Range()).
 						WithAttributeAnnotation(encryptedAttr).
 						WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/aws095.go
+++ b/internal/app/tfsec/rules/aws095.go
@@ -59,19 +59,19 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_secretsmanager_secret"},
-		CheckFunc: func(set result.Set, block *block.Block, ctx *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, ctx *hclcontext.Context) {
 
-			if block.MissingChild("kms_key_id") {
+			if resourceBlock.MissingChild("kms_key_id") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not use CMK", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not use CMK", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Info),
 				)
 				return
 			}
 
-			kmsKeyAttr := block.GetAttribute("kms_key_id")
+			kmsKeyAttr := resourceBlock.GetAttribute("kms_key_id")
 			if kmsKeyAttr.ReferencesDataBlock() {
 				ref := kmsKeyAttr.ReferenceAsString()
 				dataReferenceParts := strings.Split(ref, ".")
@@ -86,8 +86,8 @@ func init() {
 						keyIdAttr := kmsData.GetAttribute("key_id")
 						if keyIdAttr != nil && keyIdAttr.Equals("alias/aws/secretsmanager") {
 							set.Add(
-								result.New().
-									WithDescription(fmt.Sprintf("Resource '%s' explicitly uses the default CMK", block.FullName())).
+								result.New(resourceBlock).
+									WithDescription(fmt.Sprintf("Resource '%s' explicitly uses the default CMK", resourceBlock.FullName())).
 									WithRange(kmsKeyAttr.Range()).
 									WithAttributeAnnotation(kmsKeyAttr).
 									WithSeverity(severity.Info),

--- a/internal/app/tfsec/rules/aws096.go
+++ b/internal/app/tfsec/rules/aws096.go
@@ -84,12 +84,12 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_ecs_task_definition"},
-		CheckFunc: func(set result.Set, b *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if b.MissingChild("volume") {
+			if resourceBlock.MissingChild("volume") {
 			}
 
-			volumeBlocks := b.GetBlocks("volume")
+			volumeBlocks := resourceBlock.GetBlocks("volume")
 			for _, v := range volumeBlocks {
 				if v.MissingChild("efs_volume_configuration") {
 					continue
@@ -97,9 +97,9 @@ func init() {
 				efsConfigBlock := v.GetBlock("efs_volume_configuration")
 				if efsConfigBlock.MissingChild("transit_encryption") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has efs configuration with in transit encryption implicitly disabled", b.FullName())).
-							WithRange(b.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has efs configuration with in transit encryption implicitly disabled", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Error),
 					)
 				}
@@ -107,8 +107,8 @@ func init() {
 
 				if transitAttr.Equals("disabled", block.IgnoreCase) {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has efs configuration with transit encryption explicitly disabled", b.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has efs configuration with transit encryption explicitly disabled", resourceBlock.FullName())).
 							WithRange(transitAttr.Range()).
 							WithAttributeAnnotation(transitAttr).
 							WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/aws097.go
+++ b/internal/app/tfsec/rules/aws097.go
@@ -66,9 +66,9 @@ func init() {
 		Provider:       provider.AWSProvider,
 		RequiredTypes:  []string{"data"},
 		RequiredLabels: []string{"aws_iam_policy_document"},
-		CheckFunc: func(set result.Set, b *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if statementBlocks := b.GetBlocks("statement"); statementBlocks != nil {
+			if statementBlocks := resourceBlock.GetBlocks("statement"); statementBlocks != nil {
 				for _, statementBlock := range statementBlocks {
 
 					// Denying a broad set of KMS access is fine
@@ -80,9 +80,9 @@ func init() {
 						if resources := statementBlock.GetAttribute("resources"); resources != nil {
 							if resources.Contains("*") {
 								set.Add(
-									result.New().
-										WithDescription(fmt.Sprintf("Resource '%s' a policy with KMS actions for all KMS keys.", b.FullName())).
-										WithRange(b.Range()).
+									result.New(resourceBlock).
+										WithDescription(fmt.Sprintf("Resource '%s' a policy with KMS actions for all KMS keys.", resourceBlock.FullName())).
+										WithRange(resourceBlock.Range()).
 										WithAttributeAnnotation(resources).
 										WithSeverity(severity.Error),
 								)

--- a/internal/app/tfsec/rules/azu001.go
+++ b/internal/app/tfsec/rules/azu001.go
@@ -61,20 +61,20 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_network_security_rule"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			directionAttr := block.GetAttribute("direction")
+			directionAttr := resourceBlock.GetAttribute("direction")
 			if directionAttr == nil || directionAttr.Type() != cty.String || directionAttr.Value().AsString() != "Inbound" {
 			}
 
-			if prefixAttr := block.GetAttribute("source_address_prefix"); prefixAttr != nil && prefixAttr.Type() == cty.String {
+			if prefixAttr := resourceBlock.GetAttribute("source_address_prefix"); prefixAttr != nil && prefixAttr.Type() == cty.String {
 				if isOpenCidr(prefixAttr) {
-					if accessAttr := block.GetAttribute("access"); accessAttr != nil && accessAttr.Value().AsString() == "Allow" {
+					if accessAttr := resourceBlock.GetAttribute("access"); accessAttr != nil && accessAttr.Value().AsString() == "Allow" {
 						set.Add(
-							result.New().
+							result.New(resourceBlock).
 								WithDescription(fmt.Sprintf(
 									"Resource '%s' defines a fully open %s network security group rule.",
-									block.FullName(),
+									resourceBlock.FullName(),
 									strings.ToLower(directionAttr.Value().AsString()),
 								)).
 								WithRange(prefixAttr.Range()).
@@ -85,12 +85,12 @@ func init() {
 				}
 			}
 
-			if prefixesAttr := block.GetAttribute("source_address_prefixes"); prefixesAttr != nil && prefixesAttr.Value().LengthInt() > 0 {
+			if prefixesAttr := resourceBlock.GetAttribute("source_address_prefixes"); prefixesAttr != nil && prefixesAttr.Value().LengthInt() > 0 {
 				if isOpenCidr(prefixesAttr) {
-					if accessAttr := block.GetAttribute("access"); accessAttr != nil && accessAttr.Value().AsString() == "Allow" {
+					if accessAttr := resourceBlock.GetAttribute("access"); accessAttr != nil && accessAttr.Value().AsString() == "Allow" {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open security group rule.", block.FullName())).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' defines a fully open security group rule.", resourceBlock.FullName())).
 								WithRange(prefixesAttr.Range()).
 								WithAttributeAnnotation(prefixesAttr).
 								WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/azu003.go
+++ b/internal/app/tfsec/rules/azu003.go
@@ -56,8 +56,8 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_managed_disk"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			encryptionSettingsBlock := block.GetBlock("encryption_settings")
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			encryptionSettingsBlock := resourceBlock.GetBlock("encryption_settings")
 			if encryptionSettingsBlock == nil {
 				return // encryption is by default now, so this is fine
 			}
@@ -65,10 +65,10 @@ func init() {
 			enabledAttr := encryptionSettingsBlock.GetAttribute("enabled")
 			if enabledAttr != nil && enabledAttr.IsFalse() {
 				set.Add(
-					result.New().
+					result.New(resourceBlock).
 						WithDescription(fmt.Sprintf(
 							"Resource '%s' defines an unencrypted managed disk.",
-							block.FullName(),
+							resourceBlock.FullName(),
 						)).
 						WithRange(enabledAttr.Range()).
 						WithAttributeAnnotation(enabledAttr).

--- a/internal/app/tfsec/rules/azu004.go
+++ b/internal/app/tfsec/rules/azu004.go
@@ -54,15 +54,15 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_data_lake_store"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			encryptionStateAttr := block.GetAttribute("encryption_state")
+			encryptionStateAttr := resourceBlock.GetAttribute("encryption_state")
 			if encryptionStateAttr != nil && encryptionStateAttr.Type() == cty.String && encryptionStateAttr.Value().AsString() == "Disabled" {
 				set.Add(
-					result.New().
+					result.New(resourceBlock).
 						WithDescription(fmt.Sprintf(
 							"Resource '%s' defines an unencrypted data lake store.",
-							block.FullName(),
+							resourceBlock.FullName(),
 						)).
 						WithRange(encryptionStateAttr.Range()).
 						WithAttributeAnnotation(encryptionStateAttr).

--- a/internal/app/tfsec/rules/azu005.go
+++ b/internal/app/tfsec/rules/azu005.go
@@ -58,16 +58,16 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_virtual_machine"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if linuxConfigBlock := block.GetBlock("os_profile_linux_config"); linuxConfigBlock != nil {
+			if linuxConfigBlock := resourceBlock.GetBlock("os_profile_linux_config"); linuxConfigBlock != nil {
 				passwordAuthDisabledAttr := linuxConfigBlock.GetAttribute("disable_password_authentication")
 				if passwordAuthDisabledAttr != nil && passwordAuthDisabledAttr.Type() == cty.Bool && passwordAuthDisabledAttr.Value().False() {
 					set.Add(
-						result.New().
+						result.New(resourceBlock).
 							WithDescription(fmt.Sprintf(
 								"Resource '%s' has password authentication enabled. Use SSH keys instead.",
-								block.FullName(),
+								resourceBlock.FullName(),
 							)).
 							WithRange(passwordAuthDisabledAttr.Range()).
 							WithAttributeAnnotation(passwordAuthDisabledAttr).

--- a/internal/app/tfsec/rules/azu006.go
+++ b/internal/app/tfsec/rules/azu006.go
@@ -57,13 +57,13 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_kubernetes_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if networkProfileBlock := block.GetBlock("network_profile"); networkProfileBlock != nil {
+			if networkProfileBlock := resourceBlock.GetBlock("network_profile"); networkProfileBlock != nil {
 				if networkProfileBlock.GetAttribute("network_policy") == nil {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' do not have network_policy define. network_policy should be defined to have opportunity allow or block traffic to pods", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' do not have network_policy define. network_policy should be defined to have opportunity allow or block traffic to pods", resourceBlock.FullName())).
 							WithRange(networkProfileBlock.Range()).
 							WithSeverity(severity.Error),
 					)

--- a/internal/app/tfsec/rules/azu007.go
+++ b/internal/app/tfsec/rules/azu007.go
@@ -58,14 +58,14 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_kubernetes_cluster", "role_based_access_control"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			rbacBlock := block.GetBlock("role_based_access_control")
+			rbacBlock := resourceBlock.GetBlock("role_based_access_control")
 			if rbacBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines without RBAC", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines without RBAC", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
@@ -73,10 +73,10 @@ func init() {
 			enabledAttr := rbacBlock.GetAttribute("enabled")
 			if enabledAttr.Type() == cty.Bool && enabledAttr.Value().False() {
 				set.Add(
-					result.New().
+					result.New(resourceBlock).
 						WithDescription(fmt.Sprintf(
 							"Resource '%s' RBAC disabled.",
-							block.FullName(),
+							resourceBlock.FullName(),
 						)).
 						WithRange(enabledAttr.Range()).
 						WithAttributeAnnotation(enabledAttr).

--- a/internal/app/tfsec/rules/azu008.go
+++ b/internal/app/tfsec/rules/azu008.go
@@ -55,17 +55,17 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_kubernetes_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if (block.MissingChild("api_server_authorized_ip_ranges") ||
-				block.GetAttribute("api_server_authorized_ip_ranges").Value().LengthInt() < 1) &&
-				(block.MissingChild("private_cluster_enabled") ||
-					block.GetAttribute("private_cluster_enabled").IsFalse()) {
+			if (resourceBlock.MissingChild("api_server_authorized_ip_ranges") ||
+				resourceBlock.GetAttribute("api_server_authorized_ip_ranges").Value().LengthInt() < 1) &&
+				(resourceBlock.MissingChild("private_cluster_enabled") ||
+					resourceBlock.GetAttribute("private_cluster_enabled").IsFalse()) {
 				{
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defined without limited set of IP address ranges to the API server.", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defined without limited set of IP address ranges to the API server.", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Error),
 					)
 				}

--- a/internal/app/tfsec/rules/azu009.go
+++ b/internal/app/tfsec/rules/azu009.go
@@ -58,14 +58,14 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_kubernetes_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			addonProfileBlock := block.GetBlock("addon_profile")
+			addonProfileBlock := resourceBlock.GetBlock("addon_profile")
 			if addonProfileBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' AKS logging to Azure Monitoring is not configured (missing addon_profile).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' AKS logging to Azure Monitoring is not configured (missing addon_profile).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
@@ -74,9 +74,9 @@ func init() {
 			omsAgentBlock := addonProfileBlock.GetBlock("oms_agent")
 			if omsAgentBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' AKS logging to Azure Monitoring is not configured (missing oms_agent).", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' AKS logging to Azure Monitoring is not configured (missing oms_agent).", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
@@ -85,10 +85,10 @@ func init() {
 			enabledAttr := omsAgentBlock.GetAttribute("enabled")
 			if enabledAttr == nil || (enabledAttr.Type() == cty.Bool && enabledAttr.Value().False()) {
 				set.Add(
-					result.New().
+					result.New(resourceBlock).
 						WithDescription(fmt.Sprintf(
 							"Resource '%s' AKS logging to Azure Monitoring is not configured (oms_agent disabled).",
-							block.FullName(),
+							resourceBlock.FullName(),
 						)).
 						WithRange(enabledAttr.Range()).
 						WithAttributeAnnotation(enabledAttr).

--- a/internal/app/tfsec/rules/azu010.go
+++ b/internal/app/tfsec/rules/azu010.go
@@ -54,15 +54,15 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_storage_account", "enable_https_traffic_only"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			enabledAttr := block.GetAttribute("enable_https_traffic_only")
+			enabledAttr := resourceBlock.GetAttribute("enable_https_traffic_only")
 			if enabledAttr != nil && enabledAttr.Type() == cty.Bool && enabledAttr.Value().False() {
 				set.Add(
-					result.New().
+					result.New(resourceBlock).
 						WithDescription(fmt.Sprintf(
 							"Resource '%s' enable_https_traffic_only disabled.",
-							block.FullName(),
+							resourceBlock.FullName(),
 						)).
 						WithRange(enabledAttr.Range()).
 						WithAttributeAnnotation(enabledAttr).

--- a/internal/app/tfsec/rules/azu011.go
+++ b/internal/app/tfsec/rules/azu011.go
@@ -67,18 +67,18 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azure_storage_container"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			// function contents here
-			if block.HasChild("properties") {
-				properties := block.GetAttribute("properties")
+			if resourceBlock.HasChild("properties") {
+				properties := resourceBlock.GetAttribute("properties")
 				if properties.Contains("publicAccess") {
 					value := properties.MapValue("publicAccess")
 					if value == cty.StringVal("blob") || value == cty.StringVal("container") {
 						set.Add(
-							result.New().
-								WithDescription(fmt.Sprintf("Resource '%s' defines publicAccess as '%s', should be 'off .", block.FullName(), value)).
-								WithRange(block.Range()).
+							result.New(resourceBlock).
+								WithDescription(fmt.Sprintf("Resource '%s' defines publicAccess as '%s', should be 'off .", resourceBlock.FullName(), value)).
+								WithRange(resourceBlock.Range()).
 								WithSeverity(severity.Error),
 						)
 					}

--- a/internal/app/tfsec/rules/azu012.go
+++ b/internal/app/tfsec/rules/azu012.go
@@ -63,20 +63,20 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_storage_account", "azurerm_storage_account_network_rules"},
-		CheckFunc: func(set result.Set, b *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if b.IsResourceType("azurerm_storage_account") {
-				if b.MissingChild("network_rules") {
+			if resourceBlock.IsResourceType("azurerm_storage_account") {
+				if resourceBlock.MissingChild("network_rules") {
 				}
-				b = b.GetBlock("network_rules")
+				resourceBlock = resourceBlock.GetBlock("network_rules")
 			}
 
-			defaultAction := b.GetAttribute("default_action")
+			defaultAction := resourceBlock.GetAttribute("default_action")
 			if defaultAction != nil && defaultAction.Equals("Allow", block.IgnoreCase) {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a default_action of Allow. It should be Deny.", b.FullName())).
-						WithRange(b.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a default_action of Allow. It should be Deny.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/azu013.go
+++ b/internal/app/tfsec/rules/azu013.go
@@ -108,21 +108,21 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_storage_account_network_rules", "azurerm_storage_account"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.IsResourceType("azurerm_storage_account") {
-				if block.MissingChild("network_rules") {
+			if resourceBlock.IsResourceType("azurerm_storage_account") {
+				if resourceBlock.MissingChild("network_rules") {
 				}
-				block = block.GetBlock("network_rules")
+				resourceBlock = resourceBlock.GetBlock("network_rules")
 			}
 
-			if block.HasChild("bypass") {
-				bypass := block.GetAttribute("bypass")
+			if resourceBlock.HasChild("bypass") {
+				bypass := resourceBlock.GetAttribute("bypass")
 				if !bypass.Contains("AzureServices") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a network rule that doesn't allow bypass of Microsoft Services.", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a network rule that doesn't allow bypass of Microsoft Services.", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Error),
 					)
 				}

--- a/internal/app/tfsec/rules/azu014.go
+++ b/internal/app/tfsec/rules/azu014.go
@@ -67,13 +67,13 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_storage_account"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.HasChild("enable_https_traffic_only") && block.GetAttribute("enable_https_traffic_only").IsFalse() {
+			if resourceBlock.HasChild("enable_https_traffic_only") && resourceBlock.GetAttribute("enable_https_traffic_only").IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' explicitly turns off secure transfer to storage account.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' explicitly turns off secure transfer to storage account.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/azu015.go
+++ b/internal/app/tfsec/rules/azu015.go
@@ -62,13 +62,13 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_storage_account"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("min_tls_version") || block.GetAttribute("min_tls_version").IsNone("TLS1_2") {
+			if resourceBlock.MissingChild("min_tls_version") || resourceBlock.GetAttribute("min_tls_version").IsNone("TLS1_2") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have the min tls version set to TLS1_2 .", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have the min tls version set to TLS1_2 .", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}

--- a/internal/app/tfsec/rules/azu016.go
+++ b/internal/app/tfsec/rules/azu016.go
@@ -76,15 +76,15 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_storage_account"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.HasChild("queue_properties") {
-				queueProps := block.GetBlock("queue_properties")
+			if resourceBlock.HasChild("queue_properties") {
+				queueProps := resourceBlock.GetBlock("queue_properties")
 				if queueProps.MissingChild("logging") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a Queue Services storage account without Storage Analytics logging.", block.FullName())).
-							WithRange(block.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a Queue Services storage account without Storage Analytics logging.", resourceBlock.FullName())).
+							WithRange(resourceBlock.Range()).
 							WithSeverity(severity.Warning),
 					)
 				}

--- a/internal/app/tfsec/rules/azu017.go
+++ b/internal/app/tfsec/rules/azu017.go
@@ -96,13 +96,13 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_network_security_group", "azurerm_network_security_rule"},
-		CheckFunc: func(set result.Set, b *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			var securityRules block.Blocks
-			if b.IsResourceType("azurerm_network_security_group") {
-				securityRules = b.GetBlocks("security_rule")
+			if resourceBlock.IsResourceType("azurerm_network_security_group") {
+				securityRules = resourceBlock.GetBlocks("security_rule")
 			} else {
-				securityRules = append(securityRules, b)
+				securityRules = append(securityRules, resourceBlock)
 			}
 
 			for _, securityRule := range securityRules {
@@ -113,9 +113,9 @@ func init() {
 					if securityRule.HasChild("source_address_prefix") {
 						if securityRule.GetAttribute("source_address_prefix").IsAny("*", "0.0.0.0", "/0", "internet", "any") {
 							set.Add(
-								result.New().
-									WithDescription(fmt.Sprintf("Resource '%s' has a .", b.FullName())).
-									WithRange(b.Range()).
+								result.New(resourceBlock).
+									WithDescription(fmt.Sprintf("Resource '%s' has a .", resourceBlock.FullName())).
+									WithRange(resourceBlock.Range()).
 									WithSeverity(severity.Error),
 							)
 						}

--- a/internal/app/tfsec/rules/azu018.go
+++ b/internal/app/tfsec/rules/azu018.go
@@ -70,12 +70,12 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_sql_server", "azurerm_mssql_server"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if block.MissingChild("extended_auditing_policy") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.MissingChild("extended_auditing_policy") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not have extended audit configured.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not have extended audit configured.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/azu019.go
+++ b/internal/app/tfsec/rules/azu019.go
@@ -72,21 +72,21 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_sql_server", "azurerm_sql_server", "azurerm_mssql_database_extended_auditing_policy"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if !block.IsResourceType("azurerm_mssql_database_extended_auditing_policy") {
-				if block.MissingChild("extended_auditing_policy") {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if !resourceBlock.IsResourceType("azurerm_mssql_database_extended_auditing_policy") {
+				if resourceBlock.MissingChild("extended_auditing_policy") {
 				}
-				block = block.GetBlock("extended_auditing_policy")
+				resourceBlock = resourceBlock.GetBlock("extended_auditing_policy")
 			}
 
-			if block.MissingChild("retention_in_days") {
+			if resourceBlock.MissingChild("retention_in_days") {
 				// using default of unlimited
 			}
-			if block.GetAttribute("retention_in_days").LessThan(90) {
+			if resourceBlock.GetAttribute("retention_in_days").LessThan(90) {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' specifies a retention period of less than 90 days.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' specifies a retention period of less than 90 days.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/azu020.go
+++ b/internal/app/tfsec/rules/azu020.go
@@ -68,24 +68,24 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_key_vault"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("network_acls") {
+			if resourceBlock.MissingChild("network_acls") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' specifies does not specify a network acl block.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' specifies does not specify a network acl block.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
 			}
 
-			networkAcls := block.GetBlock("network_acls")
+			networkAcls := resourceBlock.GetBlock("network_acls")
 			if networkAcls == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' specifies does not specify a network acl block.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' specifies does not specify a network acl block.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
@@ -93,8 +93,8 @@ func init() {
 
 			if networkAcls.MissingChild("default_action") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' specifies does not specify a default action in the network acl.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' specifies does not specify a default action in the network acl.", resourceBlock.FullName())).
 						WithRange(networkAcls.Range()).
 						WithSeverity(severity.Error),
 				)
@@ -104,8 +104,8 @@ func init() {
 			defaultActionAttr := networkAcls.GetAttribute("default_action")
 			if !defaultActionAttr.Equals("Deny") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' specifies does not specify a network acl block.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' specifies does not specify a network acl block.", resourceBlock.FullName())).
 						WithRange(defaultActionAttr.Range()).
 						WithAttributeAnnotation(defaultActionAttr).
 						WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/azu021.go
+++ b/internal/app/tfsec/rules/azu021.go
@@ -62,21 +62,21 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_key_vault"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("purge_protection_enabled") || block.GetAttribute("purge_protection_enabled").IsFalse() {
+			if resourceBlock.MissingChild("purge_protection_enabled") || resourceBlock.GetAttribute("purge_protection_enabled").IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have purge protection enabled.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have purge protection enabled.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}
-			if block.GetAttribute("purge_protection_enabled").IsTrue() && (block.MissingChild("soft_delete_retention_days") || block.GetAttribute("soft_delete_retention_days").LessThan(1)) {
+			if resourceBlock.GetAttribute("purge_protection_enabled").IsTrue() && (resourceBlock.MissingChild("soft_delete_retention_days") || resourceBlock.GetAttribute("soft_delete_retention_days").LessThan(1)) {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have soft_delete_retention_days set in order to enabled purge protection.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have soft_delete_retention_days set in order to enabled purge protection.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}

--- a/internal/app/tfsec/rules/azu022.go
+++ b/internal/app/tfsec/rules/azu022.go
@@ -60,13 +60,13 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_key_vault_secret"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("content_type") {
+			if resourceBlock.MissingChild("content_type") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have a content type set.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have a content type set.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}

--- a/internal/app/tfsec/rules/azu023.go
+++ b/internal/app/tfsec/rules/azu023.go
@@ -60,13 +60,13 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_key_vault_secret"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("expiration_date") {
+			if resourceBlock.MissingChild("expiration_date") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have an expiration date set.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have an expiration date set.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}

--- a/internal/app/tfsec/rules/azu024.go
+++ b/internal/app/tfsec/rules/azu024.go
@@ -114,7 +114,7 @@ func init() {
 					if securityRule.HasChild("source_address_prefix") {
 						if securityRule.GetAttribute("source_address_prefix").IsAny("*", "0.0.0.0", "/0", "internet", "any") {
 							set.Add(
-								result.New().
+								result.New(resourceBlock).
 									WithDescription(fmt.Sprintf("Resource '%s' has a source address prefix of *, 0.0.0.0, /0, internet or an any. Consider using the Azure Bastion Service.", resourceBlock.FullName())).
 									WithRange(resourceBlock.Range()).
 									WithSeverity(severity.Error),

--- a/internal/app/tfsec/rules/azu025.go
+++ b/internal/app/tfsec/rules/azu025.go
@@ -60,21 +60,21 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_data_factory"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("public_network_enabled") {
+			if resourceBlock.MissingChild("public_network_enabled") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have public_network_enabled set to false, the default is true.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have public_network_enabled set to false, the default is true.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
-			if block.GetAttribute("public_network_enabled").IsTrue() || block.GetAttribute("public_network_enabled").Equals("true") || block.GetAttribute("public_network_enabled").Equals(true) {
+			if resourceBlock.GetAttribute("public_network_enabled").IsTrue() || resourceBlock.GetAttribute("public_network_enabled").Equals("true") || resourceBlock.GetAttribute("public_network_enabled").Equals(true) {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should not have public network set to true.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should not have public network set to true.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}

--- a/internal/app/tfsec/rules/azu026.go
+++ b/internal/app/tfsec/rules/azu026.go
@@ -80,13 +80,13 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_key_vault_key"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("expiration_date") {
+			if resourceBlock.MissingChild("expiration_date") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have an expiration date set.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have an expiration date set.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Warning),
 				)
 			}

--- a/internal/app/tfsec/rules/azu027.go
+++ b/internal/app/tfsec/rules/azu027.go
@@ -87,22 +87,22 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_synapse_workspace"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("managed_virtual_network_enabled") {
+			if resourceBlock.MissingChild("managed_virtual_network_enabled") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have managed_virtual_network_enabled set to true, the default is false.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have managed_virtual_network_enabled set to true, the default is false.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
 			}
-			managedNetworkAttr := block.GetAttribute("managed_virtual_network_enabled")
+			managedNetworkAttr := resourceBlock.GetAttribute("managed_virtual_network_enabled")
 			if managedNetworkAttr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have managed_virtual_network_enabled set to true, the default is false.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have managed_virtual_network_enabled set to true, the default is false.", resourceBlock.FullName())).
 						WithRange(managedNetworkAttr.Range()).
 						WithAttributeAnnotation(managedNetworkAttr).
 						WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/azu028.go
+++ b/internal/app/tfsec/rules/azu028.go
@@ -67,22 +67,22 @@ func init() {
 		Provider:       provider.AzureProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"azurerm_function_app"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("https_only") {
+			if resourceBlock.MissingChild("https_only") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have https_only set to true, the default is false.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have https_only set to true, the default is false.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
 			}
-			httpsOnlyAttr := block.GetAttribute("https_only")
+			httpsOnlyAttr := resourceBlock.GetAttribute("https_only")
 			if httpsOnlyAttr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' should have https_only set to true, the default is false.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' should have https_only set to true, the default is false.", resourceBlock.FullName())).
 						WithRange(httpsOnlyAttr.Range()).
 						WithAttributeAnnotation(httpsOnlyAttr).
 						WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/gcp001.go
+++ b/internal/app/tfsec/rules/gcp001.go
@@ -66,15 +66,15 @@ func init() {
 		Provider:       provider.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_compute_disk"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			keyBlock := block.GetBlock("disk_encryption_key")
+			keyBlock := resourceBlock.GetBlock("disk_encryption_key")
 			if keyBlock != nil {
 				if keyBlock.GetAttribute("raw_key") == nil && keyBlock.GetAttribute("kms_key_self_link") == nil {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted disk. You should specify raw_key or kms_key_self_link.", block.FullName())).
-WithRange(keyBlock.Range()).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines an unencrypted disk. You should specify raw_key or kms_key_self_link.", resourceBlock.FullName())).
+							WithRange(keyBlock.Range()).
 							WithSeverity(severity.Error),
 					)
 

--- a/internal/app/tfsec/rules/gcp003.go
+++ b/internal/app/tfsec/rules/gcp003.go
@@ -54,13 +54,13 @@ func init() {
 		Provider:       provider.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_compute_firewall"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if sourceRanges := block.GetAttribute("source_ranges"); sourceRanges != nil {
+			if sourceRanges := resourceBlock.GetAttribute("source_ranges"); sourceRanges != nil {
 				if isOpenCidr(sourceRanges) {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open inbound firewall rule.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open inbound firewall rule.", resourceBlock.FullName())).
 							WithRange(sourceRanges.Range()).
 							WithSeverity(severity.Warning),
 					)

--- a/internal/app/tfsec/rules/gcp004.go
+++ b/internal/app/tfsec/rules/gcp004.go
@@ -54,14 +54,14 @@ func init() {
 		Provider:       provider.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_compute_firewall"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if destinationRanges := block.GetAttribute("destination_ranges"); destinationRanges != nil {
+			if destinationRanges := resourceBlock.GetAttribute("destination_ranges"); destinationRanges != nil {
 
 				if isOpenCidr(destinationRanges) {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open outbound firewall rule.", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open outbound firewall rule.", resourceBlock.FullName())).
 							WithRange(destinationRanges.Range()).
 							WithSeverity(severity.Warning),
 					)

--- a/internal/app/tfsec/rules/gcp005.go
+++ b/internal/app/tfsec/rules/gcp005.go
@@ -60,14 +60,14 @@ func init() {
 		Provider:       provider.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			enable_legacy_abac := block.GetAttribute("enable_legacy_abac")
+			enable_legacy_abac := resourceBlock.GetAttribute("enable_legacy_abac")
 			if enable_legacy_abac != nil && enable_legacy_abac.Value().Type() == cty.String && enable_legacy_abac.Value().AsString() == "true" {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with ABAC enabled. Disable and rely on RBAC instead. ", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with ABAC enabled. Disable and rely on RBAC instead. ", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}

--- a/internal/app/tfsec/rules/gcp006.go
+++ b/internal/app/tfsec/rules/gcp006.go
@@ -65,15 +65,15 @@ func init() {
 		Provider:       provider.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster", "google_container_node_pool"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			nodeMetadata := block.GetBlock("node_config").GetBlock("workload_metadata_config").GetAttribute("node_metadata")
+			nodeMetadata := resourceBlock.GetBlock("node_config").GetBlock("workload_metadata_config").GetAttribute("node_metadata")
 
 			if nodeMetadata != nil && nodeMetadata.Type() == cty.String &&
 				(nodeMetadata.Value().AsString() == "EXPOSE" || nodeMetadata.Value().AsString() == "UNSPECIFIED") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with node metadata exposed. node_metadata set to EXPOSE or UNSPECIFIED disables metadata concealment. ", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with node metadata exposed. node_metadata set to EXPOSE or UNSPECIFIED disables metadata concealment. ", resourceBlock.FullName())).
 						WithRange(nodeMetadata.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/gcp007.go
+++ b/internal/app/tfsec/rules/gcp007.go
@@ -64,13 +64,13 @@ func init() {
 		Provider:       provider.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			legacyMetadataAPI := block.GetBlock("metadata").GetAttribute("disable-legacy-endpoints")
+			legacyMetadataAPI := resourceBlock.GetBlock("metadata").GetAttribute("disable-legacy-endpoints")
 			if legacyMetadataAPI.Type() == cty.String && legacyMetadataAPI.Value().AsString() != "true" || legacyMetadataAPI.Type() == cty.Bool && legacyMetadataAPI.Value().False() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with legacy metadata endpoints enabled.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with legacy metadata endpoints enabled.", resourceBlock.FullName())).
 						WithRange(legacyMetadataAPI.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/gcp008.go
+++ b/internal/app/tfsec/rules/gcp008.go
@@ -70,31 +70,31 @@ func init() {
 		Provider:       provider.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			masterAuthBlock := block.GetBlock("master_auth")
+			masterAuthBlock := resourceBlock.GetBlock("master_auth")
 			staticAuthUser := masterAuthBlock.GetAttribute("username")
 			staticAuthPass := masterAuthBlock.GetAttribute("password")
 			if masterAuthBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not disable basic auth with static passwords for client authentication. Disable this with a master_auth block container empty strings for user and password.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not disable basic auth with static passwords for client authentication. Disable this with a master_auth block container empty strings for user and password.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			} else if staticAuthUser.Type() == cty.String && staticAuthUser.Value().AsString() != "" && staticAuthPass.Type() == cty.String && staticAuthPass.Value().AsString() != "" {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster using basic auth with static passwords for client authentication. It is recommended to use OAuth or service accounts instead.", block.FullName())).
-WithRange(masterAuthBlock.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster using basic auth with static passwords for client authentication. It is recommended to use OAuth or service accounts instead.", resourceBlock.FullName())).
+						WithRange(masterAuthBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
 			issueClientCert := masterAuthBlock.GetBlock("client_certificate_config").GetAttribute("issue_client_certificate")
 			if issueClientCert.Type() == cty.Bool && issueClientCert.Value().True() || issueClientCert.Type() == cty.String && issueClientCert.Value().AsString() == "true" {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster using basic auth with client certificates for authentication. This cert has no permissions if RBAC is enabled and ABAC is disabled. It is recommended to use OAuth or service accounts instead.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster using basic auth with client certificates for authentication. This cert has no permissions if RBAC is enabled and ABAC is disabled. It is recommended to use OAuth or service accounts instead.", resourceBlock.FullName())).
 						WithRange(issueClientCert.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/gcp009.go
+++ b/internal/app/tfsec/rules/gcp009.go
@@ -64,14 +64,14 @@ func init() {
 		Provider:       provider.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			pspBlock := block.GetBlock("pod_security_policy_config")
+			pspBlock := resourceBlock.GetBlock("pod_security_policy_config")
 			if pspBlock == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with no Pod Security Policy config defined. It is recommended to define a PSP for your pods and enable PSP enforcement.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with no Pod Security Policy config defined. It is recommended to define a PSP for your pods and enable PSP enforcement.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 			}
@@ -79,8 +79,8 @@ func init() {
 			enforcePSP := pspBlock.GetAttribute("enabled")
 			if enforcePSP.Type() == cty.Bool && enforcePSP.Value().False() || enforcePSP.Type() == cty.String && enforcePSP.Value().AsString() != "true" {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with Pod Security Policy enforcement disabled. It is recommended to define a PSP for your pods and enable PSP enforcement.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with Pod Security Policy enforcement disabled. It is recommended to define a PSP for your pods and enable PSP enforcement.", resourceBlock.FullName())).
 						WithRange(enforcePSP.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/gcp010.go
+++ b/internal/app/tfsec/rules/gcp010.go
@@ -54,24 +54,24 @@ func init() {
 		Provider:       provider.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if block.MissingChild("enable_shielded_nodes") {
+			if resourceBlock.MissingChild("enable_shielded_nodes") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with shielded nodes disabled. Shielded GKE Nodes provide strong, verifiable node identity and integrity to increase the security of GKE nodes and should be enabled on all GKE clusters.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with shielded nodes disabled. Shielded GKE Nodes provide strong, verifiable node identity and integrity to increase the security of GKE nodes and should be enabled on all GKE clusters.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
 			}
 
-			enableShieldedNodesAttr := block.GetAttribute("enable_shielded_nodes")
+			enableShieldedNodesAttr := resourceBlock.GetAttribute("enable_shielded_nodes")
 
 			if enableShieldedNodesAttr.IsFalse() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with shielded nodes disabled. Shielded GKE Nodes provide strong, verifiable node identity and integrity to increase the security of GKE nodes and should be enabled on all GKE clusters.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' defines a cluster with shielded nodes disabled. Shielded GKE Nodes provide strong, verifiable node identity and integrity to increase the security of GKE nodes and should be enabled on all GKE clusters.", resourceBlock.FullName())).
 						WithRange(enableShieldedNodesAttr.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/gcp011.go
+++ b/internal/app/tfsec/rules/gcp011.go
@@ -99,23 +99,23 @@ func init() {
 			"google_storage_bucket_iam_member",
 			"google_iam_policy",
 		},
-		CheckFunc: func(set result.Set, b *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			var members []cty.Value
 			var attributes *block.Attribute
 
-			if attributes = b.GetAttribute("member"); attributes != nil {
+			if attributes = resourceBlock.GetAttribute("member"); attributes != nil {
 				members = append(members, attributes.Value())
-			} else if attributes = b.GetAttribute("members"); attributes != nil {
+			} else if attributes = resourceBlock.GetAttribute("members"); attributes != nil {
 				members = attributes.Value().AsValueSlice()
-			} else if attributes = b.GetBlock("binding").GetAttribute("members"); attributes != nil {
+			} else if attributes = resourceBlock.GetBlock("binding").GetAttribute("members"); attributes != nil {
 				members = attributes.Value().AsValueSlice()
 			}
 			for _, identities := range members {
 				if identities.IsKnown() && identities.Type() == cty.String && strings.HasPrefix(identities.AsString(), "user:") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("'%s' grants IAM to a user object. It is recommended to manage user permissions with groups.", b.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("'%s' grants IAM to a user object. It is recommended to manage user permissions with groups.", resourceBlock.FullName())).
 							WithRange(attributes.Range()).
 							WithSeverity(severity.Warning),
 					)

--- a/internal/app/tfsec/rules/gcp012.go
+++ b/internal/app/tfsec/rules/gcp012.go
@@ -57,29 +57,29 @@ func init() {
 		Provider:       provider.GCPProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"google_container_cluster", "google_container_node_pool"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if strings.HasPrefix(block.Label(), "google_container_cluster") && block.GetAttribute("remove_default_node_pool").IsTrue() {
+			if strings.HasPrefix(resourceBlock.Label(), "google_container_cluster") && resourceBlock.GetAttribute("remove_default_node_pool").IsTrue() {
 				return
 			}
 
-			if !block.HasBlock("node_config") {
+			if !resourceBlock.HasBlock("node_config") {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not define the node config and does not override the default service account. It is recommended to use a minimally privileged service account to run your GKE cluster.", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not define the node config and does not override the default service account. It is recommended to use a minimally privileged service account to run your GKE cluster.", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
 			}
 
-			displayBlock := block.GetBlock("node_config")
+			displayBlock := resourceBlock.GetBlock("node_config")
 			serviceAccount := displayBlock.GetAttribute("service_account")
 
 			if serviceAccount == nil || serviceAccount.IsEmpty() {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' does not override the default service account. It is recommended to use a minimally privileged service account to run your GKE cluster.", block.FullName())).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' does not override the default service account. It is recommended to use a minimally privileged service account to run your GKE cluster.", resourceBlock.FullName())).
 						WithRange(displayBlock.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/gen001.go
+++ b/internal/app/tfsec/rules/gen001.go
@@ -69,21 +69,21 @@ func init() {
 		},
 		Provider:      provider.GeneralProvider,
 		RequiredTypes: []string{"variable"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			if len(block.Labels()) == 0 || !security.IsSensitiveAttribute(block.TypeLabel()) {
+			if len(resourceBlock.Labels()) == 0 || !security.IsSensitiveAttribute(resourceBlock.TypeLabel()) {
 				return
 			}
 
-			for _, attribute := range block.GetAttributes() {
+			for _, attribute := range resourceBlock.GetAttributes() {
 				if attribute.Name() == "default" {
 					val := attribute.Value()
 					if val.Type() != cty.String {
 						continue
 					}
 					if val.AsString() != "" {
-						set.Add(result.New().
-							WithDescription(fmt.Sprintf("Variable '%s' includes a potentially sensitive default value.", block.FullName())).
+						set.Add(result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Variable '%s' includes a potentially sensitive default value.", resourceBlock.FullName())).
 							WithRange(attribute.Range()).
 							WithAttributeAnnotation(attribute).
 							WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/gen002.go
+++ b/internal/app/tfsec/rules/gen002.go
@@ -67,13 +67,13 @@ func init() {
 		},
 		Provider:      provider.GeneralProvider,
 		RequiredTypes: []string{"locals"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			for _, attribute := range block.GetAttributes() {
+			for _, attribute := range resourceBlock.GetAttributes() {
 				if security.IsSensitiveAttribute(attribute.Name()) {
 					if attribute.Type() == cty.String && attribute.Value().AsString() != "" {
-						set.Add(result.New().
-							WithDescription(fmt.Sprintf("Local '%s' includes a potentially sensitive value which is defined within the project.", block.FullName())).
+						set.Add(result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Local '%s' includes a potentially sensitive value which is defined within the project.", resourceBlock.FullName())).
 							WithRange(attribute.Range()).
 							WithAttributeAnnotation(attribute).
 							WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/gen003.go
+++ b/internal/app/tfsec/rules/gen003.go
@@ -89,21 +89,21 @@ func init() {
 		},
 		Provider:      provider.GeneralProvider,
 		RequiredTypes: []string{"resource", "provider", "module"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			attributes := block.GetAttributes()
+			attributes := resourceBlock.GetAttributes()
 
 		SKIP:
 			for _, attribute := range attributes {
 				for _, whitelisted := range sensitiveWhitelist {
-					if whitelisted.Resource == block.TypeLabel() && whitelisted.Attribute == attribute.Name() {
+					if whitelisted.Resource == resourceBlock.TypeLabel() && whitelisted.Attribute == attribute.Name() {
 						continue SKIP
 					}
 				}
 				if security.IsSensitiveAttribute(attribute.Name()) {
 					if attribute.Type() == cty.String && attribute.Value().AsString() != "" {
-						set.Add(result.New().
-							WithDescription(fmt.Sprintf("Block '%s' includes a potentially sensitive attribute which is defined within the project.", block.FullName())).
+						set.Add(result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Block '%s' includes a potentially sensitive attribute which is defined within the project.", resourceBlock.FullName())).
 							WithRange(attribute.Range()).
 							WithAttributeAnnotation(attribute).
 							WithSeverity(severity.Warning),

--- a/internal/app/tfsec/rules/gen004.go
+++ b/internal/app/tfsec/rules/gen004.go
@@ -72,15 +72,15 @@ func init() {
 		Provider:       provider.GeneralProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"github_repository"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
-			privateAttribute := block.GetAttribute("private")
-			visibilityAttribute := block.GetAttribute("visibility")
+			privateAttribute := resourceBlock.GetAttribute("private")
+			visibilityAttribute := resourceBlock.GetAttribute("visibility")
 			if visibilityAttribute == nil && privateAttribute == nil {
 				set.Add(
-					result.New().
-						WithDescription(fmt.Sprintf("Resource '%s' is missing `private` or `visibility` attribute - one of these is required to make repository private", block.FullName())).
-						WithRange(block.Range()).
+					result.New(resourceBlock).
+						WithDescription(fmt.Sprintf("Resource '%s' is missing `private` or `visibility` attribute - one of these is required to make repository private", resourceBlock.FullName())).
+						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)
 				return
@@ -90,8 +90,8 @@ func init() {
 			if visibilityAttribute != nil {
 				if visibilityAttribute.Equals("public") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has visibility set to public - visibility should be set to `private` or `internal` to make repository private", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has visibility set to public - visibility should be set to `private` or `internal` to make repository private", resourceBlock.FullName())).
 							WithRange(visibilityAttribute.Range()).
 							WithAttributeAnnotation(visibilityAttribute).
 							WithSeverity(severity.Error),
@@ -106,8 +106,8 @@ func init() {
 			if privateAttribute != nil {
 				if privateAttribute.Equals(false) {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' has private set to false - it should be set to `true` to make repository private", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' has private set to false - it should be set to `true` to make repository private", resourceBlock.FullName())).
 							WithRange(privateAttribute.Range()).
 							WithSeverity(severity.Error),
 					)

--- a/internal/app/tfsec/rules/oci001.go
+++ b/internal/app/tfsec/rules/oci001.go
@@ -57,12 +57,12 @@ func init() {
 		Provider:       provider.OracleProvider,
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"opc_compute_ip_address_reservation"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if attr := block.GetAttribute("ip_address_pool"); attr != nil {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if attr := resourceBlock.GetAttribute("ip_address_pool"); attr != nil {
 				if attr.IsAny("public-ippool") {
 					set.Add(
-						result.New().
-							WithDescription(fmt.Sprintf("Resource '%s' is using an IP from a public IP pool", block.FullName())).
+						result.New(resourceBlock).
+							WithDescription(fmt.Sprintf("Resource '%s' is using an IP from a public IP pool", resourceBlock.FullName())).
 							WithRange(attr.Range()).
 							WithAttributeAnnotation(attr).
 							WithSeverity(severity.Warning),

--- a/internal/app/tfsec/scanner/scanner.go
+++ b/internal/app/tfsec/scanner/scanner.go
@@ -64,7 +64,7 @@ func (scanner *Scanner) Scan(blocks []*block.Block) []result.Result {
 					debug.Log("Running rule for %s on %s.%s (%s)...", r.ID, checkBlock.Type(), checkBlock.FullName(), checkBlock.Range().Filename)
 					ruleResults := rule.CheckRule(r, checkBlock, context)
 					if scanner.includePassed && ruleResults == nil {
-						res := result.New().WithRange(checkBlock.Range()).WithStatus(result.Passed).WithSeverity(severity.None)
+						res := result.New(checkBlock).WithRange(checkBlock.Range()).WithStatus(result.Passed).WithSeverity(severity.None)
 						results = append(results, *res)
 					} else if ruleResults != nil {
 						for _, ruleResult := range ruleResults.All() {

--- a/internal/app/tfsec/test/ignore_test.go
+++ b/internal/app/tfsec/test/ignore_test.go
@@ -70,9 +70,9 @@ func Test_IgnoreSpecific(t *testing.T) {
 	scanner.RegisterCheckRule(rule.Rule{
 		ID:             "ABC123",
 		RequiredLabels: []string{"bad"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			set.Add(
-				result.New().WithDescription("example problem").WithRange(block.Range()).WithSeverity(severity.Error),
+				result.New(resourceBlock).WithDescription("example problem").WithRange(resourceBlock.Range()).WithSeverity(severity.Error),
 			)
 		},
 	})
@@ -80,9 +80,9 @@ func Test_IgnoreSpecific(t *testing.T) {
 	scanner.RegisterCheckRule(rule.Rule{
 		ID:             "DEF456",
 		RequiredLabels: []string{"bad"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			set.Add(
-				result.New().WithDescription("example problem").WithRange(block.Range()).WithSeverity(severity.Error),
+				result.New(resourceBlock).WithDescription("example problem").WithRange(resourceBlock.Range()).WithSeverity(severity.Error),
 			)
 		},
 	})

--- a/internal/app/tfsec/test/setup_test.go
+++ b/internal/app/tfsec/test/setup_test.go
@@ -49,10 +49,10 @@ resource "problem" "x" {
 		},
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"problem"},
-		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context) {
-			if block.GetAttribute("bad") != nil {
+		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.GetAttribute("bad") != nil {
 				set.Add(
-					result.New().WithDescription("example problem").WithRange(block.Range()).WithSeverity(severity.Error),
+					result.New(resourceBlock).WithDescription("example problem").WithRange(resourceBlock.Range()).WithSeverity(severity.Error),
 				)
 			}
 		},

--- a/internal/app/tfsec/test/wildcard_test.go
+++ b/internal/app/tfsec/test/wildcard_test.go
@@ -64,7 +64,7 @@ func Test_WildcardMatchingOnRequiredLabels(t *testing.T) {
 			RequiredLabels: []string{test.pattern},
 			CheckFunc: func(set result.Set, rootBlock *block.Block, ctx *hclcontext.Context) {
 				set.Add(
-					result.New().WithDescription(fmt.Sprintf("Custom check failed for resource %s.", rootBlock.FullName())).
+					result.New(rootBlock).WithDescription(fmt.Sprintf("Custom check failed for resource %s.", rootBlock.FullName())).
 						WithRange(rootBlock.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -24,6 +24,7 @@ type Result struct {
 	RangeAnnotation string            `json:"-"`
 	Severity        severity.Severity `json:"severity"`
 	Status          Status            `json:"status"`
+	topLevelBlock   *block.Block
 }
 
 type Status string
@@ -34,9 +35,10 @@ const (
 	Ignored Status = "ignored"
 )
 
-func New() *Result {
+func New(resourceBlock *block.Block) *Result {
 	return &Result{
-		Status: Failed,
+		Status:        Failed,
+		topLevelBlock: resourceBlock,
 	}
 }
 

--- a/pkg/result/set.go
+++ b/pkg/result/set.go
@@ -33,7 +33,13 @@ func (s *resultSet) Add(result *Result) {
 		WithRuleSummary(s.ruleSummary).
 		WithImpact(s.impact).
 		WithResolution(s.resolution).
-		WithRuleProvider(s.ruleProvider)
+		WithRuleProvider(s.ruleProvider).
+		WithLinks(s.links)
+
+	if result.Range.Filename == "" {
+		result.Range = result.topLevelBlock.Range()
+	}
+
 	s.results = append(s.results, *result)
 }
 


### PR DESCRIPTION
- sub result blocks dont always have the range on them, this can happen
when the check is detecting the absence of something. In cases like
this, set the range of the block to the outer range of the check block
