### PR TITLE
Allow file output for text

### DIFF
--- a/cmd/tfsec/main.go
+++ b/cmd/tfsec/main.go
@@ -169,6 +169,9 @@ var rootCmd = &cobra.Command{
 		}
 
 		if outputFlag != "" {
+			if format == "" {
+				format = "text"
+			}
 			f, err := os.OpenFile(filepath.Clean(outputFlag), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 			if err != nil {
 				fmt.Println(err)

--- a/internal/app/tfsec/formatters/text.go
+++ b/internal/app/tfsec/formatters/text.go
@@ -6,15 +6,13 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/tfsec/tfsec/pkg/severity"
-
 	"github.com/tfsec/tfsec/pkg/result"
 )
 
-func FormatText(_ io.Writer, results []result.Result, _ string, options ...FormatterOption) error {
+func FormatText(writer io.Writer, results []result.Result, _ string, options ...FormatterOption) error {
 
 	if len(results) == 0 || len(results) == countPassedResults(results) {
-		fmt.Print("\nNo problems detected!\n")
+		fmt.Fprint(writer, "\nNo problems detected!\n")
 		return nil
 	}
 
@@ -28,7 +26,7 @@ func FormatText(_ io.Writer, results []result.Result, _ string, options ...Forma
 
 	var sev string
 
-	fmt.Printf("\n%d potential problems detected:\n\n", len(results)-countPassedResults(results))
+	fmt.Fprintf(writer, "\n%d potential problems detected:\n\n", len(results)-countPassedResults(results))
 	for i, res := range results {
 
 		var link string
@@ -36,28 +34,21 @@ func FormatText(_ io.Writer, results []result.Result, _ string, options ...Forma
 			link = res.Links[0]
 		}
 
-		fmt.Printf("Check %d\n", i+1)
+		fmt.Fprintf(writer, "Check %d\n", i+1)
 
 		if includePassedChecks && res.Passed() {
 			sev = "PASSED"
 		} else {
-			switch res.Severity {
-			case severity.Error:
-				sev = fmt.Sprintf("%s", res.Severity)
-			case severity.Warning:
-				sev = fmt.Sprintf("%s", res.Severity)
-			default:
-				sev = fmt.Sprintf("%s", res.Severity)
-			}
+			sev = string(res.Severity)
 		}
 
-		fmt.Printf(`
+		fmt.Fprintf(writer, `
   [%s][%s] %s
   %s
 
 `, res.RuleID, sev, res.Description, res.Range.String())
-		outputCode(res)
-		fmt.Printf("  %s\n\n", link)
+		outputCode(res, writer)
+		fmt.Fprintf(writer, "  %s\n\n", link)
 	}
 
 	return nil
@@ -65,7 +56,7 @@ func FormatText(_ io.Writer, results []result.Result, _ string, options ...Forma
 }
 
 // output the lines of code which caused a problem, if available
-func outputCode(result result.Result) {
+func outputCode(result result.Result, writer io.Writer) {
 	data, err := ioutil.ReadFile(result.Range.Filename)
 	if err != nil {
 		return
@@ -83,17 +74,17 @@ func outputCode(result result.Result) {
 	}
 
 	for lineNo := start; lineNo <= end; lineNo++ {
-		fmt.Printf("  % 6d | ", lineNo)
+		fmt.Fprintf(writer, "  % 6d | ", lineNo)
 		if lineNo >= result.Range.StartLine && lineNo <= result.Range.EndLine {
 			if lineNo == result.Range.StartLine && result.RangeAnnotation != "" {
-				fmt.Printf("%s    %s\n", lines[lineNo], result.RangeAnnotation)
+				fmt.Fprintf(writer, "%s    %s\n", lines[lineNo], result.RangeAnnotation)
 			} else {
-				fmt.Printf("%s\n", lines[lineNo])
+				fmt.Fprintf(writer, "%s\n", lines[lineNo])
 			}
 		} else {
-			fmt.Printf("%s\n", lines[lineNo])
+			fmt.Fprintf(writer, "%s\n", lines[lineNo])
 		}
 	}
 
-	fmt.Println("")
+	fmt.Fprintln(writer, "")
 }

--- a/internal/app/tfsec/rules/aws006.go
+++ b/internal/app/tfsec/rules/aws006.go
@@ -72,6 +72,7 @@ func init() {
 					set.Add(
 						result.New(resourceBlock).
 							WithDescription(fmt.Sprintf("Resource '%s' defines a fully open ingress security group rule.", resourceBlock.FullName())).
+							WithAttributeAnnotation(cidrBlocksAttr).
 							WithRange(cidrBlocksAttr.Range()).
 							WithSeverity(severity.Warning),
 					)


### PR DESCRIPTION
When the --out flag is used with the default or text formatter it has an empty file.

- update text formatter to write to io.Writer
- redirect default formatter to text when a file output is used

Resolves #789
