### PR TITLE
Support the load_balancer_type of gateway

### DIFF
--- a/internal/app/tfsec/rules/aws005.go
+++ b/internal/app/tfsec/rules/aws005.go
@@ -55,6 +55,9 @@ func init() {
 		RequiredTypes:  []string{"resource"},
 		RequiredLabels: []string{"aws_alb", "aws_elb", "aws_lb"},
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
+			if resourceBlock.HasChild("load_balancer_type") && resourceBlock.GetAttribute("load_balancer_type").Equals("gateway") {
+				return
+			}
 			if internalAttr := resourceBlock.GetAttribute("internal"); internalAttr == nil {
 				set.Add(
 					result.New(resourceBlock).

--- a/internal/app/tfsec/test/aws005_test.go
+++ b/internal/app/tfsec/test/aws005_test.go
@@ -53,6 +53,16 @@ resource "aws_lb" "my-resource" {
 }`,
 			mustExcludeResultCode: rules.AWSExternallyExposedLoadBalancer,
 		},
+		{
+			name: "check aws_lb when explicitly is a gateway",
+			source: `
+resource "aws_lb" "gwlb" {
+	name               = var.gwlb_name
+	load_balancer_type = "gateway"
+	subnets            = local.appliance_subnets_id
+  }`,
+			mustExcludeResultCode: rules.AWSExternallyExposedLoadBalancer,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
the requirement for `internal` does not apply when using a `gateway`
load balancer type

Resolves #795
