### PR TITLE
fix scan result description in AWS090

### DIFF
--- a/internal/app/tfsec/rules/aws090.go
+++ b/internal/app/tfsec/rules/aws090.go
@@ -79,7 +79,7 @@ func init() {
 			}
 			set.Add(
 				result.New(resourceBlock).
-					WithDescription(fmt.Sprintf("Resoure '%s' does not have codeInsights enabled", resourceBlock.FullName())).
+					WithDescription(fmt.Sprintf("Resoure '%s' does not have containerInsights enabled", resourceBlock.FullName())).
 					WithRange(resourceBlock.Range()).
 					WithSeverity(severity.Info),
 			)


### PR DESCRIPTION
Scan result description in AWS090 is for containerInsights, not codeInsights.