### PR TITLE
traverse the load balancer to check type

### DIFF
--- a/internal/app/tfsec/block/attribute.go
+++ b/internal/app/tfsec/block/attribute.go
@@ -359,7 +359,7 @@ func (attr *Attribute) GreaterThanOrEqualTo(checkValue interface{}) bool {
 	return false
 }
 
-func (attr *Attribute) ReferencesDataBlock() bool {
+func (attr *Attribute) IsDataBlockReference() bool {
 	switch t := attr.hclAttribute.Expr.(type) {
 	case *hclsyntax.ScopeTraversalExpr:
 		split := t.Traversal.SimpleSplit()
@@ -382,6 +382,30 @@ func (attr *Attribute) ReferenceAsString() string {
 	}
 	if len(refParts) > 0 {
 		return strings.Join(refParts, ".")
+	}
+	return ""
+}
+
+func (attr *Attribute) IsResourceBlockReference(resourceType string) bool {
+	switch t := attr.hclAttribute.Expr.(type) {
+	case *hclsyntax.ScopeTraversalExpr:
+		split := t.Traversal.SimpleSplit()
+		return split.Abs.RootName() == resourceType
+	}
+	return false
+}
+
+func (attr *Attribute) GetReferencedResourceBlocksName() string {
+	switch t := attr.hclAttribute.Expr.(type) {
+	case *hclsyntax.ScopeTraversalExpr:
+		parts := t.Traversal.SimpleSplit()
+		for _, p := range parts.Rel {
+			switch part := p.(type) {
+			case hcl.TraverseAttr:
+				// the first name on the Rel is the label for the attribute, so return that
+				return part.Name
+			}
+		}
 	}
 	return ""
 }

--- a/internal/app/tfsec/hclcontext/context.go
+++ b/internal/app/tfsec/hclcontext/context.go
@@ -53,3 +53,22 @@ func (c *Context) GetProviderBlocksByProvider(providerName string, alias string)
 	}
 	return results
 }
+
+func (c *Context) GetReferencedBlock(referringAttr *block.Attribute) (*block.Block, error) {
+	resType, err := referringAttr.GetReferencedResourceBlockType()
+	if err != nil {
+		return nil, err
+	}
+	resName, err := referringAttr.GetReferencedResourceBlocksName()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, resource := range c.GetResourcesByType(resType) {
+		if resource.NameLabel() == resName {
+			return resource, nil
+		}
+	}
+
+	return nil, fmt.Errorf("did not find a suitable block to reference")
+}

--- a/internal/app/tfsec/rules/aws016.go
+++ b/internal/app/tfsec/rules/aws016.go
@@ -78,7 +78,7 @@ func init() {
 				return
 			}
 
-			if kmsKeyIDAttr.ReferencesDataBlock() {
+			if kmsKeyIDAttr.IsDataBlockReference() {
 				ref := kmsKeyIDAttr.ReferenceAsString()
 				dataReferenceParts := strings.Split(ref, ".")
 				if len(dataReferenceParts) < 3 {

--- a/internal/app/tfsec/rules/aws095.go
+++ b/internal/app/tfsec/rules/aws095.go
@@ -72,7 +72,7 @@ func init() {
 			}
 
 			kmsKeyAttr := resourceBlock.GetAttribute("kms_key_id")
-			if kmsKeyAttr.ReferencesDataBlock() {
+			if kmsKeyAttr.IsDataBlockReference() {
 				ref := kmsKeyAttr.ReferenceAsString()
 				dataReferenceParts := strings.Split(ref, ".")
 				if len(dataReferenceParts) < 3 {

--- a/internal/app/tfsec/test/aws004_test.go
+++ b/internal/app/tfsec/test/aws004_test.go
@@ -38,6 +38,26 @@ resource "aws_alb_listener" "my-listener" {
 			mustIncludeResultCode: rules.AWSPlainHTTP,
 		},
 		{
+			name: "check aws_alb_listeneer should continue checks if the referenced if a load balancer is not gateway",
+			source: `
+resource "aws_lb" "gwlb" {
+
+	load_balancer_type = "application"
+
+}
+
+resource "aws_lb_listener" "gwlb_listener" {
+	load_balancer_arn = aws_lb.gwlb.id
+	  
+	default_action {
+		target_group_arn = aws_lb_target_group.gwlb_target_group.id
+		  type             = "forward"
+		}
+}
+	`,
+			mustIncludeResultCode: rules.AWSPlainHTTP,
+		},
+		{
 			name: "check aws_alb_listener using HTTPS",
 			source: `
 resource "aws_alb_listener" "my-listener" {
@@ -60,6 +80,26 @@ resource "aws_alb_listener" "my-listener" {
 		}
 	}
 }`,
+			mustExcludeResultCode: rules.AWSPlainHTTP,
+		},
+		{
+			name: "check aws_alb_listeneer should pass if a type is gateway",
+			source: `
+resource "aws_lb" "gwlb" {
+
+	load_balancer_type = "gateway"
+
+}
+
+resource "aws_lb_listener" "gwlb_listener" {
+	load_balancer_arn = aws_lb.gwlb.id
+	  
+	default_action {
+		target_group_arn = aws_lb_target_group.gwlb_target_group.id
+		  type             = "forward"
+		}
+}
+	`,
 			mustExcludeResultCode: rules.AWSPlainHTTP,
 		},
 	}


### PR DESCRIPTION
- add attribute functions to walk the scope and find the related
  resource to a reference so further checks can be performed
- rename `ReferencesDataBlock` to `IsDataBlockReference` to make the intent clearer