### PR TITLE
Update rules to have default severity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,7 @@ func init() {
 		RequiredLabels: []string{"aws_gibson"},
         
         	// the actual logic for your check
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, block *parser.Block, _ *hclcontext.Context) {
 			// TODO: add check logic here
 		},
@@ -107,7 +108,8 @@ Now all that's left is writing the logic itself. You'll likely find it useful he
 ```go
 ...
 
-        CheckFunc: func(set result.Set, block *parser.Block, _ *hclcontext.Context) {
+        DefaultSeverity: severity.Warning,
+CheckFunc: func(set result.Set, block *parser.Block, _ *hclcontext.Context) {
 
             if attr := block.GetAttribute("hackable"); attr != nil && attr.Value().Type() == cty.Bool {
                 if attr.Value().True() {

--- a/cmd/tfsec-skeleton/templates.go
+++ b/cmd/tfsec-skeleton/templates.go
@@ -43,6 +43,7 @@ func init() {
 		Provider:       provider.{{.ProviderLongName}}Provider,
 		RequiredTypes:  []string{{.RequiredTypes}},
 		RequiredLabels: []string{{.RequiredLabels}},
+		DefaultSeverity: severity.Warning, //TODO set the default severity
 		CheckFunc: func(set result.Set, block *block.Block, _ *hclcontext.Context){
 				
 			// function contents here

--- a/internal/app/tfsec/custom/processing.go
+++ b/internal/app/tfsec/custom/processing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/tfsec/tfsec/pkg/provider"
+	"github.com/tfsec/tfsec/pkg/severity"
 
 	"github.com/tfsec/tfsec/pkg/result"
 
@@ -129,9 +130,10 @@ func processFoundChecks(checks ChecksFile) {
 					Impact:     customCheck.Impact,
 					Resolution: customCheck.Resolution,
 				},
-				Provider:       provider.CustomProvider,
-				RequiredTypes:  customCheck.RequiredTypes,
-				RequiredLabels: customCheck.RequiredLabels,
+				Provider:        provider.CustomProvider,
+				RequiredTypes:   customCheck.RequiredTypes,
+				RequiredLabels:  customCheck.RequiredLabels,
+				DefaultSeverity: severity.Warning,
 				CheckFunc: func(set result.Set, rootBlock *block.Block, ctx *hclcontext.Context) {
 					matchSpec := customCheck.MatchSpec
 					if !evalMatchSpec(rootBlock, matchSpec, ctx) {

--- a/internal/app/tfsec/rules/aws001.go
+++ b/internal/app/tfsec/rules/aws001.go
@@ -54,9 +54,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_s3_bucket"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_s3_bucket"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if attr := resourceBlock.GetAttribute("acl"); attr != nil {
 				if attr.IsAny("public-read", "public-read-write", "website") {

--- a/internal/app/tfsec/rules/aws002.go
+++ b/internal/app/tfsec/rules/aws002.go
@@ -52,9 +52,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_s3_bucket"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_s3_bucket"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if loggingBlock := resourceBlock.GetBlock("logging"); loggingBlock == nil {
 				if resourceBlock.GetAttribute("acl") != nil && resourceBlock.GetAttribute("acl").Equals("log-delivery-write") {

--- a/internal/app/tfsec/rules/aws003.go
+++ b/internal/app/tfsec/rules/aws003.go
@@ -50,9 +50,10 @@ func init() {
 				"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_db_security_group", "aws_redshift_security_group", "aws_elasticache_security_group"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_db_security_group", "aws_redshift_security_group", "aws_elasticache_security_group"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			set.Add(
 				result.New(resourceBlock).

--- a/internal/app/tfsec/rules/aws004.go
+++ b/internal/app/tfsec/rules/aws004.go
@@ -55,9 +55,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_lb_listener", "aws_alb_listener"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_lb_listener", "aws_alb_listener"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, ctx *hclcontext.Context) {
 			if resourceBlock.HasChild("load_balancer_arn") {
 				lbaAttr := resourceBlock.GetAttribute("load_balancer_arn")

--- a/internal/app/tfsec/rules/aws005.go
+++ b/internal/app/tfsec/rules/aws005.go
@@ -51,9 +51,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_alb", "aws_elb", "aws_lb"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_alb", "aws_elb", "aws_lb"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.HasChild("load_balancer_type") && resourceBlock.GetAttribute("load_balancer_type").Equals("gateway") {
 				return

--- a/internal/app/tfsec/rules/aws006.go
+++ b/internal/app/tfsec/rules/aws006.go
@@ -53,9 +53,10 @@ func init() {
 				"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules-reference.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_security_group_rule"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_security_group_rule"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			typeAttr := resourceBlock.GetAttribute("type")

--- a/internal/app/tfsec/rules/aws007.go
+++ b/internal/app/tfsec/rules/aws007.go
@@ -53,9 +53,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_security_group_rule"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_security_group_rule"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			typeAttr := resourceBlock.GetAttribute("type")

--- a/internal/app/tfsec/rules/aws008.go
+++ b/internal/app/tfsec/rules/aws008.go
@@ -53,9 +53,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_security_group"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_security_group"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(resultSet result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			for _, directionBlock := range resourceBlock.GetBlocks("ingress") {

--- a/internal/app/tfsec/rules/aws009.go
+++ b/internal/app/tfsec/rules/aws009.go
@@ -53,9 +53,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_security_group"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_security_group"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			for _, directionBlock := range resourceBlock.GetBlocks("egress") {

--- a/internal/app/tfsec/rules/aws010.go
+++ b/internal/app/tfsec/rules/aws010.go
@@ -61,9 +61,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_lb_listener", "aws_alb_listener"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_lb_listener", "aws_alb_listener"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if sslPolicyAttr := resourceBlock.GetAttribute("ssl_policy"); sslPolicyAttr != nil && sslPolicyAttr.Type() == cty.String {

--- a/internal/app/tfsec/rules/aws011.go
+++ b/internal/app/tfsec/rules/aws011.go
@@ -51,9 +51,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_db_instance", "aws_dms_replication_instance", "aws_rds_cluster_instance", "aws_redshift_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_db_instance", "aws_dms_replication_instance", "aws_rds_cluster_instance", "aws_redshift_cluster"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if publicAttr := resourceBlock.GetAttribute("publicly_accessible"); publicAttr != nil && publicAttr.Type() == cty.Bool {

--- a/internal/app/tfsec/rules/aws012.go
+++ b/internal/app/tfsec/rules/aws012.go
@@ -53,9 +53,10 @@ func init() {
 				"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_launch_configuration", "aws_instance"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_launch_configuration", "aws_instance"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if publicAttr := resourceBlock.GetAttribute("associate_public_ip_address"); publicAttr != nil && publicAttr.Type() == cty.Bool {

--- a/internal/app/tfsec/rules/aws013.go
+++ b/internal/app/tfsec/rules/aws013.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/tfsec/tfsec/pkg/provider"
 
+	"github.com/tfsec/tfsec/internal/app/tfsec/debug"
 	"github.com/tfsec/tfsec/internal/app/tfsec/hclcontext"
 
 	"github.com/tfsec/tfsec/internal/app/tfsec/block"
@@ -80,9 +81,10 @@ func init() {
 				"https://www.vaultproject.io/",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_ecs_task_definition"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_ecs_task_definition"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if definitionsAttr := resourceBlock.GetAttribute("container_definitions"); definitionsAttr != nil && definitionsAttr.Type() == cty.String {
@@ -96,6 +98,7 @@ func init() {
 				}
 
 				if err := json.Unmarshal(rawJSON, &definitions); err != nil {
+					debug.Log("an error occured processing th json: %s", err.Error())
 				}
 
 				for _, definition := range definitions {

--- a/internal/app/tfsec/rules/aws014.go
+++ b/internal/app/tfsec/rules/aws014.go
@@ -56,9 +56,10 @@ func init() {
 				"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/RootDeviceStorage.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_launch_configuration"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_launch_configuration"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			var encryptionByDefault bool

--- a/internal/app/tfsec/rules/aws015.go
+++ b/internal/app/tfsec/rules/aws015.go
@@ -52,9 +52,10 @@ func init() {
 				"https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_sqs_queue"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_sqs_queue"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			kmsKeyIDAttr := resourceBlock.GetAttribute("kms_master_key_id")

--- a/internal/app/tfsec/rules/aws016.go
+++ b/internal/app/tfsec/rules/aws016.go
@@ -53,9 +53,10 @@ func init() {
 				"https://docs.aws.amazon.com/sns/latest/dg/sns-server-side-encryption.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_sns_topic"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_sns_topic"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, ctx *hclcontext.Context) {
 
 			kmsKeyIDAttr := resourceBlock.GetAttribute("kms_master_key_id")
@@ -82,6 +83,7 @@ func init() {
 				ref := kmsKeyIDAttr.ReferenceAsString()
 				dataReferenceParts := strings.Split(ref, ".")
 				if len(dataReferenceParts) < 3 {
+					return
 				}
 				blockType := dataReferenceParts[0]
 				blockName := dataReferenceParts[1]

--- a/internal/app/tfsec/rules/aws017.go
+++ b/internal/app/tfsec/rules/aws017.go
@@ -59,9 +59,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-encryption.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_s3_bucket"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_s3_bucket"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("server_side_encryption_configuration") {

--- a/internal/app/tfsec/rules/aws018.go
+++ b/internal/app/tfsec/rules/aws018.go
@@ -71,9 +71,10 @@ func init() {
 				"https://www.cloudconformity.com/knowledge-base/aws/EC2/security-group-rules-description.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_security_group", "aws_security_group_rule"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_security_group", "aws_security_group_rule"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.MissingChild("description") {
 				set.Add(

--- a/internal/app/tfsec/rules/aws019.go
+++ b/internal/app/tfsec/rules/aws019.go
@@ -53,9 +53,10 @@ func init() {
 				"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_kms_key"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_kms_key"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			keyUsageAttr := resourceBlock.GetAttribute("key_usage")
 

--- a/internal/app/tfsec/rules/aws020.go
+++ b/internal/app/tfsec/rules/aws020.go
@@ -58,9 +58,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-cloudfront-to-s3-origin.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_cloudfront_distribution"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_cloudfront_distribution"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			defaultBehaviorBlock := resourceBlock.GetBlock("default_cache_behavior")

--- a/internal/app/tfsec/rules/aws021.go
+++ b/internal/app/tfsec/rules/aws021.go
@@ -58,9 +58,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_cloudfront_distribution"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_cloudfront_distribution"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			viewerCertificateBlock := resourceBlock.GetBlock("viewer_certificate")

--- a/internal/app/tfsec/rules/aws022.go
+++ b/internal/app/tfsec/rules/aws022.go
@@ -61,9 +61,10 @@ func init() {
 				"https://docs.aws.amazon.com/msk/latest/developerguide/msk-encryption.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_msk_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_msk_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			defaultBehaviorBlock := resourceBlock.GetBlock("encryption_info")

--- a/internal/app/tfsec/rules/aws023.go
+++ b/internal/app/tfsec/rules/aws023.go
@@ -63,9 +63,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_ecr_repository"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_ecr_repository"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			ecrScanStatusBlock := resourceBlock.GetBlock("image_scanning_configuration")

--- a/internal/app/tfsec/rules/aws024.go
+++ b/internal/app/tfsec/rules/aws024.go
@@ -54,9 +54,10 @@ func init() {
 				"https://docs.aws.amazon.com/streams/latest/dev/server-side-encryption.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_kinesis_stream"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_kinesis_stream"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			encryptionTypeAttr := resourceBlock.GetAttribute("encryption_type")

--- a/internal/app/tfsec/rules/aws025.go
+++ b/internal/app/tfsec/rules/aws025.go
@@ -52,9 +52,10 @@ func init() {
 				"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-custom-domain-tls-version.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_api_gateway_domain_name"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_api_gateway_domain_name"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			securityPolicyAttr := resourceBlock.GetAttribute("security_policy")

--- a/internal/app/tfsec/rules/aws031.go
+++ b/internal/app/tfsec/rules/aws031.go
@@ -60,9 +60,10 @@ func init() {
 				"https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/encryption-at-rest.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_elasticsearch_domain"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_elasticsearch_domain"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			encryptionBlock := resourceBlock.GetBlock("encrypt_at_rest")

--- a/internal/app/tfsec/rules/aws032.go
+++ b/internal/app/tfsec/rules/aws032.go
@@ -61,9 +61,10 @@ func init() {
 				"https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/ntn.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_elasticsearch_domain"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_elasticsearch_domain"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			encryptionBlock := resourceBlock.GetBlock("node_to_node_encryption")

--- a/internal/app/tfsec/rules/aws033.go
+++ b/internal/app/tfsec/rules/aws033.go
@@ -64,9 +64,10 @@ func init() {
 				"https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-data-protection.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_elasticsearch_domain"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_elasticsearch_domain"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			endpointBlock := resourceBlock.GetBlock("domain_endpoint_options")

--- a/internal/app/tfsec/rules/aws034.go
+++ b/internal/app/tfsec/rules/aws034.go
@@ -62,9 +62,10 @@ func init() {
 				"https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-data-protection.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_elasticsearch_domain"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_elasticsearch_domain"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			endpointBlock := resourceBlock.GetBlock("domain_endpoint_options")

--- a/internal/app/tfsec/rules/aws035.go
+++ b/internal/app/tfsec/rules/aws035.go
@@ -56,9 +56,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/at-rest-encryption.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_elasticache_replication_group"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_elasticache_replication_group"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			encryptionAttr := resourceBlock.GetAttribute("at_rest_encryption_enabled")

--- a/internal/app/tfsec/rules/aws036.go
+++ b/internal/app/tfsec/rules/aws036.go
@@ -56,9 +56,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_elasticache_replication_group"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_elasticache_replication_group"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			encryptionAttr := resourceBlock.GetAttribute("transit_encryption_enabled")

--- a/internal/app/tfsec/rules/aws037.go
+++ b/internal/app/tfsec/rules/aws037.go
@@ -61,9 +61,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_iam_account_password_policy"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_iam_account_password_policy"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if attr := resourceBlock.GetAttribute("password_reuse_prevention"); attr == nil {
 				set.Add(

--- a/internal/app/tfsec/rules/aws038.go
+++ b/internal/app/tfsec/rules/aws038.go
@@ -60,9 +60,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_iam_account_password_policy"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_iam_account_password_policy"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if attr := resourceBlock.GetAttribute("max_password_age"); attr == nil {
 				set.Add(

--- a/internal/app/tfsec/rules/aws039.go
+++ b/internal/app/tfsec/rules/aws039.go
@@ -60,9 +60,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_iam_account_password_policy"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_iam_account_password_policy"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if attr := resourceBlock.GetAttribute("minimum_password_length"); attr == nil {
 				set.Add(

--- a/internal/app/tfsec/rules/aws040.go
+++ b/internal/app/tfsec/rules/aws040.go
@@ -58,9 +58,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_iam_account_password_policy"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_iam_account_password_policy"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if attr := resourceBlock.GetAttribute("require_symbols"); attr == nil {
 				set.Add(

--- a/internal/app/tfsec/rules/aws041.go
+++ b/internal/app/tfsec/rules/aws041.go
@@ -58,9 +58,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_iam_account_password_policy"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_iam_account_password_policy"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if attr := resourceBlock.GetAttribute("require_numbers"); attr == nil {
 				set.Add(

--- a/internal/app/tfsec/rules/aws042.go
+++ b/internal/app/tfsec/rules/aws042.go
@@ -58,9 +58,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_iam_account_password_policy"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_iam_account_password_policy"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if attr := resourceBlock.GetAttribute("require_lowercase_characters"); attr == nil {
 				set.Add(

--- a/internal/app/tfsec/rules/aws043.go
+++ b/internal/app/tfsec/rules/aws043.go
@@ -59,9 +59,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_iam_account_password_policy"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_iam_account_password_policy"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if attr := resourceBlock.GetAttribute("require_uppercase_characters"); attr == nil {
 				set.Add(

--- a/internal/app/tfsec/rules/aws044.go
+++ b/internal/app/tfsec/rules/aws044.go
@@ -52,9 +52,10 @@ func init() {
 				"https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"provider"},
-		RequiredLabels: []string{"aws"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"provider"},
+		RequiredLabels:  []string{"aws"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if accessKeyAttribute := resourceBlock.GetAttribute("access_key"); accessKeyAttribute != nil && accessKeyAttribute.Type() == cty.String {

--- a/internal/app/tfsec/rules/aws045.go
+++ b/internal/app/tfsec/rules/aws045.go
@@ -106,9 +106,10 @@ func init() {
 				"https://docs.aws.amazon.com/waf/latest/developerguide/cloudfront-features.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_cloudfront_distribution"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_cloudfront_distribution"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, context *hclcontext.Context) {
 
 			wafAclIdBlock := resourceBlock.GetAttribute("web_acl_id")

--- a/internal/app/tfsec/rules/aws046.go
+++ b/internal/app/tfsec/rules/aws046.go
@@ -64,9 +64,10 @@ func init() {
 			GoodExample: AWSIamPolicyWildcardActionsGoodExample,
 			Links:       []string{},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"data"},
-		RequiredLabels: []string{"aws_iam_policy_document"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"data"},
+		RequiredLabels:  []string{"aws_iam_policy_document"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if statementBlocks := resourceBlock.GetBlocks("statement"); statementBlocks != nil {

--- a/internal/app/tfsec/rules/aws047.go
+++ b/internal/app/tfsec/rules/aws047.go
@@ -80,12 +80,14 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_sqs_queue_policy"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_sqs_queue_policy"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.GetAttribute("policy").Value().Type() != cty.String {
+				return
 			}
 
 			rawJSON := []byte(resourceBlock.GetAttribute("policy").Value().AsString())

--- a/internal/app/tfsec/rules/aws048.go
+++ b/internal/app/tfsec/rules/aws048.go
@@ -54,9 +54,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_efs_file_system"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_efs_file_system"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			efsEnabledAttr := resourceBlock.GetAttribute("encrypted")

--- a/internal/app/tfsec/rules/aws049.go
+++ b/internal/app/tfsec/rules/aws049.go
@@ -61,9 +61,10 @@ func init() {
 				"https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_network_acl_rule"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_network_acl_rule"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			egressAttr := resourceBlock.GetAttribute("egress")

--- a/internal/app/tfsec/rules/aws050.go
+++ b/internal/app/tfsec/rules/aws050.go
@@ -59,22 +59,26 @@ func init() {
 				"https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_network_acl_rule"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_network_acl_rule"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			egressAttr := resourceBlock.GetAttribute("egress")
 			actionAttr := resourceBlock.GetAttribute("rule_action")
 			protoAttr := resourceBlock.GetAttribute("protocol")
 
-			if egressAttr.Type() == cty.Bool && egressAttr.Value().True() {
+			if egressAttr != nil && egressAttr.IsTrue() {
+				return
 			}
 
 			if actionAttr == nil || actionAttr.Type() != cty.String {
+				return
 			}
 
 			if actionAttr.Value().AsString() != "allow" {
+				return
 			}
 
 			if cidrBlockAttr := resourceBlock.GetAttribute("cidr_block"); cidrBlockAttr != nil {
@@ -89,6 +93,7 @@ func init() {
 								WithSeverity(severity.Error),
 						)
 					} else {
+						return
 					}
 				}
 
@@ -106,6 +111,7 @@ func init() {
 								WithSeverity(severity.Error),
 						)
 					} else {
+						return
 					}
 				}
 

--- a/internal/app/tfsec/rules/aws051.go
+++ b/internal/app/tfsec/rules/aws051.go
@@ -53,9 +53,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_rds_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_rds_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			kmsKeyIdAttr := resourceBlock.GetAttribute("kms_key_id")

--- a/internal/app/tfsec/rules/aws052.go
+++ b/internal/app/tfsec/rules/aws052.go
@@ -52,9 +52,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_db_instance"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_db_instance"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("storage_encrypted") {

--- a/internal/app/tfsec/rules/aws053.go
+++ b/internal/app/tfsec/rules/aws053.go
@@ -57,9 +57,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.htm",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_rds_cluster_instance", "aws_db_instance"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_rds_cluster_instance", "aws_db_instance"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.HasChild("performance_insights_enabled") && resourceBlock.GetAttribute("performance_insights_enabled").IsTrue() {

--- a/internal/app/tfsec/rules/aws057.go
+++ b/internal/app/tfsec/rules/aws057.go
@@ -87,9 +87,10 @@ func init() {
 				"https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createdomain-configure-slow-logs.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_elasticsearch_domain"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_elasticsearch_domain"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("log_publishing_options") {

--- a/internal/app/tfsec/rules/aws058.go
+++ b/internal/app/tfsec/rules/aws058.go
@@ -59,9 +59,10 @@ func init() {
 				"https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-permission.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_lambda_permission"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_lambda_permission"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.HasChild("principal") {

--- a/internal/app/tfsec/rules/aws059.go
+++ b/internal/app/tfsec/rules/aws059.go
@@ -91,9 +91,10 @@ func init() {
 				"https://docs.aws.amazon.com/athena/latest/ug/encryption.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_athena_database", "aws_athena_workgroup"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_athena_database", "aws_athena_workgroup"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			blockName := resourceBlock.FullName()

--- a/internal/app/tfsec/rules/aws060.go
+++ b/internal/app/tfsec/rules/aws060.go
@@ -83,9 +83,10 @@ func init() {
 				"https://docs.aws.amazon.com/athena/latest/ug/manage-queries-control-costs-with-workgroups.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_athena_workgroup"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_athena_workgroup"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("configuration") {

--- a/internal/app/tfsec/rules/aws061.go
+++ b/internal/app/tfsec/rules/aws061.go
@@ -74,9 +74,10 @@ func init() {
 				"https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_apigatewayv2_stage", "aws_api_gateway_stage"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_apigatewayv2_stage", "aws_api_gateway_stage"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("access_log_settings") {

--- a/internal/app/tfsec/rules/aws062.go
+++ b/internal/app/tfsec/rules/aws062.go
@@ -69,12 +69,14 @@ func init() {
 				"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-add-user-data.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_instance"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_instance"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("user_data") {
+				return
 			}
 
 			userDataAttr := resourceBlock.GetAttribute("user_data")

--- a/internal/app/tfsec/rules/aws063.go
+++ b/internal/app/tfsec/rules/aws063.go
@@ -68,9 +68,10 @@ func init() {
 				"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/receive-cloudtrail-log-files-from-multiple-regions.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_cloudtrail"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_cloudtrail"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.MissingChild("is_multi_region_trail") {
 				set.Add(

--- a/internal/app/tfsec/rules/aws064.go
+++ b/internal/app/tfsec/rules/aws064.go
@@ -71,9 +71,10 @@ func init() {
 				"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-validation-intro.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_cloudtrail"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_cloudtrail"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.MissingChild("enable_log_file_validation") {
 				set.Add(

--- a/internal/app/tfsec/rules/aws065.go
+++ b/internal/app/tfsec/rules/aws065.go
@@ -72,9 +72,10 @@ func init() {
 				"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/encrypting-cloudtrail-log-files-with-aws-kms.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_cloudtrail"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_cloudtrail"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("kms_key_id") {

--- a/internal/app/tfsec/rules/aws066.go
+++ b/internal/app/tfsec/rules/aws066.go
@@ -66,9 +66,10 @@ func init() {
 				"https://aws.amazon.com/about-aws/whats-new/2020/03/amazon-eks-adds-envelope-encryption-for-secrets-with-aws-kms/",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_eks_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_eks_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("encryption_config") {

--- a/internal/app/tfsec/rules/aws067.go
+++ b/internal/app/tfsec/rules/aws067.go
@@ -74,9 +74,10 @@ func init() {
 				"https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_eks_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_eks_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			controlPlaneLogging := []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}

--- a/internal/app/tfsec/rules/aws068.go
+++ b/internal/app/tfsec/rules/aws068.go
@@ -63,9 +63,10 @@ func init() {
 				"https://docs.aws.amazon.com/eks/latest/userguide/create-public-private-vpc.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_eks_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_eks_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("vpc_config") {

--- a/internal/app/tfsec/rules/aws069.go
+++ b/internal/app/tfsec/rules/aws069.go
@@ -63,9 +63,10 @@ func init() {
 				"https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_eks_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_eks_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("vpc_config") {

--- a/internal/app/tfsec/rules/aws070.go
+++ b/internal/app/tfsec/rules/aws070.go
@@ -61,9 +61,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#log_publishing_options",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_elasticsearch_domain"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_elasticsearch_domain"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			logPublishingOptions := resourceBlock.GetBlocks("log_publishing_options")
 			if len(logPublishingOptions) > 0 {

--- a/internal/app/tfsec/rules/aws071.go
+++ b/internal/app/tfsec/rules/aws071.go
@@ -56,9 +56,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_cloudfront_distribution"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_cloudfront_distribution"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("logging_config") {

--- a/internal/app/tfsec/rules/aws072.go
+++ b/internal/app/tfsec/rules/aws072.go
@@ -85,9 +85,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#viewer_protocol_policy",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_cloudfront_distribution"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_cloudfront_distribution"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			defaultCacheBlock := resourceBlock.GetBlock("default_cache_behavior")

--- a/internal/app/tfsec/rules/aws073.go
+++ b/internal/app/tfsec/rules/aws073.go
@@ -58,9 +58,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block#ignore_public_acls",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_s3_bucket_public_access_block"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_s3_bucket_public_access_block"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("ignore_public_acls") {

--- a/internal/app/tfsec/rules/aws074.go
+++ b/internal/app/tfsec/rules/aws074.go
@@ -58,9 +58,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block#block_public_acls",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_s3_bucket_public_access_block"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_s3_bucket_public_access_block"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.MissingChild("block_public_acls") {
 				set.Add(

--- a/internal/app/tfsec/rules/aws075.go
+++ b/internal/app/tfsec/rules/aws075.go
@@ -58,9 +58,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block#restrict_public_buckets¡",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_s3_bucket_public_access_block"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_s3_bucket_public_access_block"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.MissingChild("restrict_public_buckets") {
 				set.Add(

--- a/internal/app/tfsec/rules/aws076.go
+++ b/internal/app/tfsec/rules/aws076.go
@@ -58,9 +58,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block#block_public_policy",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_s3_bucket_public_access_block"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_s3_bucket_public_access_block"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.MissingChild("block_public_policy") {
 				set.Add(

--- a/internal/app/tfsec/rules/aws077.go
+++ b/internal/app/tfsec/rules/aws077.go
@@ -55,9 +55,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#versioning",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_s3_bucket"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_s3_bucket"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("versioning") {

--- a/internal/app/tfsec/rules/aws078.go
+++ b/internal/app/tfsec/rules/aws078.go
@@ -62,9 +62,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_ecr_repository"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_ecr_repository"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			imageTagMutabilityAttr := resourceBlock.GetAttribute("image_tag_mutability")

--- a/internal/app/tfsec/rules/aws079.go
+++ b/internal/app/tfsec/rules/aws079.go
@@ -57,9 +57,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#metadata-options",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_instance"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_instance"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			metaDataOptions := resourceBlock.GetBlock("metadata_options")

--- a/internal/app/tfsec/rules/aws080.go
+++ b/internal/app/tfsec/rules/aws080.go
@@ -101,9 +101,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project#encryption_disabled",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_codebuild_project"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_codebuild_project"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			blocks := resourceBlock.GetBlocks("secondary_artifacts")

--- a/internal/app/tfsec/rules/aws081.go
+++ b/internal/app/tfsec/rules/aws081.go
@@ -71,9 +71,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dax_cluster#server_side_encryption",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_dax_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_dax_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("server_side_encryption") {

--- a/internal/app/tfsec/rules/aws082.go
+++ b/internal/app/tfsec/rules/aws082.go
@@ -50,9 +50,10 @@ func init() {
 				"https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_default_vpc"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_default_vpc"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			set.Add(
 				result.New(resourceBlock).

--- a/internal/app/tfsec/rules/aws083.go
+++ b/internal/app/tfsec/rules/aws083.go
@@ -72,9 +72,10 @@ func init() {
 				"https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_alb", "aws_lb"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_alb", "aws_lb"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.GetAttribute("load_balancer_type").Equals("application", block.IgnoreCase) {

--- a/internal/app/tfsec/rules/aws084.go
+++ b/internal/app/tfsec/rules/aws084.go
@@ -72,9 +72,10 @@ func init() {
 				"https://docs.aws.amazon.com/workspaces/latest/adminguide/encrypt-workspaces.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_workspaces_workspace"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_workspaces_workspace"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("root_volume_encryption_enabled") {

--- a/internal/app/tfsec/rules/aws085.go
+++ b/internal/app/tfsec/rules/aws085.go
@@ -62,9 +62,10 @@ func init() {
 				"https://docs.aws.amazon.com/config/latest/developerguide/aggregate-data.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_config_configuration_aggregator"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_config_configuration_aggregator"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			aggBlock := resourceBlock.GetFirstMatchingBlock("account_aggregation_source", "organization_aggregation_source")

--- a/internal/app/tfsec/rules/aws086.go
+++ b/internal/app/tfsec/rules/aws086.go
@@ -74,9 +74,10 @@ func init() {
 				"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_dynamodb_table"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_dynamodb_table"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("point_in_time_recovery") {

--- a/internal/app/tfsec/rules/aws087.go
+++ b/internal/app/tfsec/rules/aws087.go
@@ -64,9 +64,10 @@ func init() {
 				"https://docs.aws.amazon.com/redshift/latest/mgmt/managing-clusters-vpc.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_redshift_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_redshift_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.MissingChild("cluster_subnet_group_name") {
 				set.Add(

--- a/internal/app/tfsec/rules/aws088.go
+++ b/internal/app/tfsec/rules/aws088.go
@@ -64,9 +64,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-automatic.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_elasticache_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_elasticache_cluster"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			engineAttr := resourceBlock.GetAttribute("engine")

--- a/internal/app/tfsec/rules/aws089.go
+++ b/internal/app/tfsec/rules/aws089.go
@@ -53,9 +53,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_cloudwatch_log_group"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_cloudwatch_log_group"},
+		DefaultSeverity: severity.Info,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.MissingChild("kms_key_id") {
 				set.Add(

--- a/internal/app/tfsec/rules/aws090.go
+++ b/internal/app/tfsec/rules/aws090.go
@@ -55,9 +55,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_ecs_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_ecs_cluster"},
+		DefaultSeverity: severity.Info,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			settingsBlock := resourceBlock.GetBlocks("setting")

--- a/internal/app/tfsec/rules/aws091.go
+++ b/internal/app/tfsec/rules/aws091.go
@@ -91,9 +91,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html#USER_WorkingWithAutomatedBackups.BackupRetention",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_rds_cluster", "aws_db_instance"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_rds_cluster", "aws_db_instance"},
+		DefaultSeverity: severity.Info,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.HasChild("replicate_source_db") {
 				return

--- a/internal/app/tfsec/rules/aws092.go
+++ b/internal/app/tfsec/rules/aws092.go
@@ -93,9 +93,10 @@ func init() {
 				"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EncryptionAtRest.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_dynamodb_table"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_dynamodb_table"},
+		DefaultSeverity: severity.Info,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("server_side_encryption") {

--- a/internal/app/tfsec/rules/aws093.go
+++ b/internal/app/tfsec/rules/aws093.go
@@ -70,9 +70,10 @@ func init() {
 				"https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_ecr_repository"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_ecr_repository"},
+		DefaultSeverity: severity.Info,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("encryption_configuration") {

--- a/internal/app/tfsec/rules/aws094.go
+++ b/internal/app/tfsec/rules/aws094.go
@@ -66,9 +66,10 @@ func init() {
 				"https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-db-encryption.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_redshift_cluster"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_redshift_cluster"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("encrypted") {

--- a/internal/app/tfsec/rules/aws095.go
+++ b/internal/app/tfsec/rules/aws095.go
@@ -56,9 +56,10 @@ func init() {
 				"https://docs.aws.amazon.com/kms/latest/developerguide/services-secrets-manager.html#asm-encrypt",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_secretsmanager_secret"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_secretsmanager_secret"},
+		DefaultSeverity: severity.Info,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, ctx *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("kms_key_id") {

--- a/internal/app/tfsec/rules/aws096.go
+++ b/internal/app/tfsec/rules/aws096.go
@@ -81,9 +81,10 @@ func init() {
 				"https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"aws_ecs_task_definition"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"aws_ecs_task_definition"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("volume") {

--- a/internal/app/tfsec/rules/aws097.go
+++ b/internal/app/tfsec/rules/aws097.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"fmt"
+
 	"github.com/tfsec/tfsec/pkg/severity"
 
 	"github.com/tfsec/tfsec/pkg/result"
@@ -63,9 +64,10 @@ func init() {
 				"https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-kms-1",
 			},
 		},
-		Provider:       provider.AWSProvider,
-		RequiredTypes:  []string{"data"},
-		RequiredLabels: []string{"aws_iam_policy_document"},
+		Provider:        provider.AWSProvider,
+		RequiredTypes:   []string{"data"},
+		RequiredLabels:  []string{"aws_iam_policy_document"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if statementBlocks := resourceBlock.GetBlocks("statement"); statementBlocks != nil {

--- a/internal/app/tfsec/rules/azu001.go
+++ b/internal/app/tfsec/rules/azu001.go
@@ -58,9 +58,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/azurerm/r/network_security_rule.html",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_network_security_rule"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_network_security_rule"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			directionAttr := resourceBlock.GetAttribute("direction")

--- a/internal/app/tfsec/rules/azu002.go
+++ b/internal/app/tfsec/rules/azu002.go
@@ -57,9 +57,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/azurerm/r/network_security_rule.html",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_network_security_rule"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_network_security_rule"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			directionAttr := resourceBlock.GetAttribute("direction")

--- a/internal/app/tfsec/rules/azu003.go
+++ b/internal/app/tfsec/rules/azu003.go
@@ -53,9 +53,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/azurerm/r/managed_disk.html",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_managed_disk"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_managed_disk"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			encryptionSettingsBlock := resourceBlock.GetBlock("encryption_settings")
 			if encryptionSettingsBlock == nil {

--- a/internal/app/tfsec/rules/azu004.go
+++ b/internal/app/tfsec/rules/azu004.go
@@ -51,9 +51,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/azurerm/r/data_lake_store.html",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_data_lake_store"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_data_lake_store"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			encryptionStateAttr := resourceBlock.GetAttribute("encryption_state")

--- a/internal/app/tfsec/rules/azu005.go
+++ b/internal/app/tfsec/rules/azu005.go
@@ -55,9 +55,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/azurerm/r/virtual_machine.html",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_virtual_machine"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_virtual_machine"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if linuxConfigBlock := resourceBlock.GetBlock("os_profile_linux_config"); linuxConfigBlock != nil {

--- a/internal/app/tfsec/rules/azu006.go
+++ b/internal/app/tfsec/rules/azu006.go
@@ -54,9 +54,10 @@ func init() {
 				"https://kubernetes.io/docs/concepts/services-networking/network-policies",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_kubernetes_cluster"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_kubernetes_cluster"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if networkProfileBlock := resourceBlock.GetBlock("network_profile"); networkProfileBlock != nil {

--- a/internal/app/tfsec/rules/azu007.go
+++ b/internal/app/tfsec/rules/azu007.go
@@ -55,9 +55,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/aks/concepts-identity",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_kubernetes_cluster", "role_based_access_control"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_kubernetes_cluster", "role_based_access_control"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			rbacBlock := resourceBlock.GetBlock("role_based_access_control")

--- a/internal/app/tfsec/rules/azu008.go
+++ b/internal/app/tfsec/rules/azu008.go
@@ -52,9 +52,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/azurerm/r/kubernetes_cluster.html#api_server_authorized_ip_ranges",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_kubernetes_cluster"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_kubernetes_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if (resourceBlock.MissingChild("api_server_authorized_ip_ranges") ||

--- a/internal/app/tfsec/rules/azu009.go
+++ b/internal/app/tfsec/rules/azu009.go
@@ -55,9 +55,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/azure-monitor/insights/container-insights-onboard",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_kubernetes_cluster"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_kubernetes_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			addonProfileBlock := resourceBlock.GetBlock("addon_profile")

--- a/internal/app/tfsec/rules/azu010.go
+++ b/internal/app/tfsec/rules/azu010.go
@@ -51,9 +51,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/storage/blobs/security-recommendations",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_storage_account", "enable_https_traffic_only"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_storage_account", "enable_https_traffic_only"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			enabledAttr := resourceBlock.GetAttribute("enable_https_traffic_only")

--- a/internal/app/tfsec/rules/azu011.go
+++ b/internal/app/tfsec/rules/azu011.go
@@ -64,9 +64,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-configure?tabs=portal#set-the-public-access-level-for-a-container",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azure_storage_container"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azure_storage_container"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			// function contents here

--- a/internal/app/tfsec/rules/azu012.go
+++ b/internal/app/tfsec/rules/azu012.go
@@ -60,13 +60,15 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/firewall/rule-processing",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_storage_account", "azurerm_storage_account_network_rules"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_storage_account", "azurerm_storage_account_network_rules"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.IsResourceType("azurerm_storage_account") {
 				if resourceBlock.MissingChild("network_rules") {
+					return
 				}
 				resourceBlock = resourceBlock.GetBlock("network_rules")
 			}

--- a/internal/app/tfsec/rules/azu013.go
+++ b/internal/app/tfsec/rules/azu013.go
@@ -105,13 +105,15 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/storage/common/storage-network-security#trusted-microsoft-services",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_storage_account_network_rules", "azurerm_storage_account"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_storage_account_network_rules", "azurerm_storage_account"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.IsResourceType("azurerm_storage_account") {
 				if resourceBlock.MissingChild("network_rules") {
+					return
 				}
 				resourceBlock = resourceBlock.GetBlock("network_rules")
 			}

--- a/internal/app/tfsec/rules/azu014.go
+++ b/internal/app/tfsec/rules/azu014.go
@@ -64,9 +64,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/storage/common/storage-require-secure-transfer",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_storage_account"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_storage_account"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.HasChild("enable_https_traffic_only") && resourceBlock.GetAttribute("enable_https_traffic_only").IsFalse() {

--- a/internal/app/tfsec/rules/azu015.go
+++ b/internal/app/tfsec/rules/azu015.go
@@ -59,9 +59,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/storage/common/transport-layer-security-configure-minimum-version",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_storage_account"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_storage_account"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("min_tls_version") || resourceBlock.GetAttribute("min_tls_version").IsNone("TLS1_2") {

--- a/internal/app/tfsec/rules/azu016.go
+++ b/internal/app/tfsec/rules/azu016.go
@@ -73,9 +73,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/storage/common/storage-analytics-logging?tabs=dotnet",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_storage_account"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_storage_account"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.HasChild("queue_properties") {

--- a/internal/app/tfsec/rules/azu017.go
+++ b/internal/app/tfsec/rules/azu017.go
@@ -93,9 +93,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule#source_port_ranges",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_network_security_group", "azurerm_network_security_rule"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_network_security_group", "azurerm_network_security_rule"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			var securityRules block.Blocks

--- a/internal/app/tfsec/rules/azu018.go
+++ b/internal/app/tfsec/rules/azu018.go
@@ -67,9 +67,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/azure-sql/database/auditing-overview",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_sql_server", "azurerm_mssql_server"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_sql_server", "azurerm_mssql_server"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.MissingChild("extended_auditing_policy") {
 				set.Add(

--- a/internal/app/tfsec/rules/azu019.go
+++ b/internal/app/tfsec/rules/azu019.go
@@ -69,18 +69,21 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/azure-sql/database/auditing-overview",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_sql_server", "azurerm_sql_server", "azurerm_mssql_database_extended_auditing_policy"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_sql_server", "azurerm_sql_server", "azurerm_mssql_database_extended_auditing_policy"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if !resourceBlock.IsResourceType("azurerm_mssql_database_extended_auditing_policy") {
 				if resourceBlock.MissingChild("extended_auditing_policy") {
+					return
 				}
 				resourceBlock = resourceBlock.GetBlock("extended_auditing_policy")
 			}
 
 			if resourceBlock.MissingChild("retention_in_days") {
 				// using default of unlimited
+				return
 			}
 			if resourceBlock.GetAttribute("retention_in_days").LessThan(90) {
 				set.Add(

--- a/internal/app/tfsec/rules/azu020.go
+++ b/internal/app/tfsec/rules/azu020.go
@@ -65,9 +65,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/key-vault/general/network-security",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_key_vault"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_key_vault"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("network_acls") {

--- a/internal/app/tfsec/rules/azu021.go
+++ b/internal/app/tfsec/rules/azu021.go
@@ -59,9 +59,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview#purge-protection",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_key_vault"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_key_vault"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("purge_protection_enabled") || resourceBlock.GetAttribute("purge_protection_enabled").IsFalse() {

--- a/internal/app/tfsec/rules/azu022.go
+++ b/internal/app/tfsec/rules/azu022.go
@@ -57,9 +57,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/key-vault/secrets/about-secrets",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_key_vault_secret"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_key_vault_secret"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("content_type") {

--- a/internal/app/tfsec/rules/azu023.go
+++ b/internal/app/tfsec/rules/azu023.go
@@ -57,9 +57,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/key-vault/secrets/about-secrets",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_key_vault_secret"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_key_vault_secret"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("expiration_date") {

--- a/internal/app/tfsec/rules/azu024.go
+++ b/internal/app/tfsec/rules/azu024.go
@@ -94,9 +94,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/bastion/tutorial-create-host-portal",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_network_security_group", "azurerm_network_security_rule"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_network_security_group", "azurerm_network_security_rule"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			var securityRules block.Blocks

--- a/internal/app/tfsec/rules/azu025.go
+++ b/internal/app/tfsec/rules/azu025.go
@@ -57,9 +57,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/data-factory/data-movement-security-considerations#hybrid-scenarios",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_data_factory"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_data_factory"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("public_network_enabled") {

--- a/internal/app/tfsec/rules/azu026.go
+++ b/internal/app/tfsec/rules/azu026.go
@@ -77,9 +77,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/powershell/module/az.keyvault/update-azkeyvaultkey?view=azps-5.8.0#example-1--modify-a-key-to-enable-it--and-set-the-expiration-date-and-tags",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_key_vault_key"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_key_vault_key"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("expiration_date") {

--- a/internal/app/tfsec/rules/azu027.go
+++ b/internal/app/tfsec/rules/azu027.go
@@ -84,9 +84,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/synapse-analytics/security/synapse-workspace-managed-vnet",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_synapse_workspace"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_synapse_workspace"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("managed_virtual_network_enabled") {

--- a/internal/app/tfsec/rules/azu028.go
+++ b/internal/app/tfsec/rules/azu028.go
@@ -64,9 +64,10 @@ func init() {
 				"https://docs.microsoft.com/en-us/azure/azure-functions/security-concepts",
 			},
 		},
-		Provider:       provider.AzureProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"azurerm_function_app"},
+		Provider:        provider.AzureProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"azurerm_function_app"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("https_only") {

--- a/internal/app/tfsec/rules/gcp001.go
+++ b/internal/app/tfsec/rules/gcp001.go
@@ -63,9 +63,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/google/r/compute_disk.html",
 			},
 		},
-		Provider:       provider.GCPProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"google_compute_disk"},
+		Provider:        provider.GCPProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"google_compute_disk"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			keyBlock := resourceBlock.GetBlock("disk_encryption_key")

--- a/internal/app/tfsec/rules/gcp003.go
+++ b/internal/app/tfsec/rules/gcp003.go
@@ -51,9 +51,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/google/r/compute_firewall.html",
 			},
 		},
-		Provider:       provider.GCPProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"google_compute_firewall"},
+		Provider:        provider.GCPProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"google_compute_firewall"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if sourceRanges := resourceBlock.GetAttribute("source_ranges"); sourceRanges != nil {

--- a/internal/app/tfsec/rules/gcp004.go
+++ b/internal/app/tfsec/rules/gcp004.go
@@ -51,9 +51,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/google/r/compute_firewall.html",
 			},
 		},
-		Provider:       provider.GCPProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"google_compute_firewall"},
+		Provider:        provider.GCPProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"google_compute_firewall"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if destinationRanges := resourceBlock.GetAttribute("destination_ranges"); destinationRanges != nil {

--- a/internal/app/tfsec/rules/gcp005.go
+++ b/internal/app/tfsec/rules/gcp005.go
@@ -57,9 +57,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/google/r/container_cluster.html#enable_legacy_abac",
 			},
 		},
-		Provider:       provider.GCPProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"google_container_cluster"},
+		Provider:        provider.GCPProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"google_container_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			enable_legacy_abac := resourceBlock.GetAttribute("enable_legacy_abac")

--- a/internal/app/tfsec/rules/gcp006.go
+++ b/internal/app/tfsec/rules/gcp006.go
@@ -62,9 +62,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_metadata",
 			},
 		},
-		Provider:       provider.GCPProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"google_container_cluster", "google_container_node_pool"},
+		Provider:        provider.GCPProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"google_container_cluster", "google_container_node_pool"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			nodeMetadata := resourceBlock.GetBlock("node_config").GetBlock("workload_metadata_config").GetAttribute("node_metadata")

--- a/internal/app/tfsec/rules/gcp007.go
+++ b/internal/app/tfsec/rules/gcp007.go
@@ -61,9 +61,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/google/r/container_cluster.html#metadata",
 			},
 		},
-		Provider:       provider.GCPProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"google_container_cluster"},
+		Provider:        provider.GCPProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"google_container_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			legacyMetadataAPI := resourceBlock.GetBlock("metadata").GetAttribute("disable-legacy-endpoints")

--- a/internal/app/tfsec/rules/gcp008.go
+++ b/internal/app/tfsec/rules/gcp008.go
@@ -67,9 +67,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_auth",
 			},
 		},
-		Provider:       provider.GCPProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"google_container_cluster"},
+		Provider:        provider.GCPProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"google_container_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			masterAuthBlock := resourceBlock.GetBlock("master_auth")

--- a/internal/app/tfsec/rules/gcp009.go
+++ b/internal/app/tfsec/rules/gcp009.go
@@ -61,9 +61,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/google/r/container_cluster.html#pod_security_policy_config",
 			},
 		},
-		Provider:       provider.GCPProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"google_container_cluster"},
+		Provider:        provider.GCPProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"google_container_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			pspBlock := resourceBlock.GetBlock("pod_security_policy_config")

--- a/internal/app/tfsec/rules/gcp010.go
+++ b/internal/app/tfsec/rules/gcp010.go
@@ -51,9 +51,10 @@ func init() {
 				"https://www.terraform.io/docs/providers/google/r/container_cluster.html#enable_shielded_nodes",
 			},
 		},
-		Provider:       provider.GCPProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"google_container_cluster"},
+		Provider:        provider.GCPProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"google_container_cluster"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if resourceBlock.MissingChild("enable_shielded_nodes") {

--- a/internal/app/tfsec/rules/gcp011.go
+++ b/internal/app/tfsec/rules/gcp011.go
@@ -99,6 +99,7 @@ func init() {
 			"google_storage_bucket_iam_member",
 			"google_iam_policy",
 		},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			var members []cty.Value

--- a/internal/app/tfsec/rules/gcp012.go
+++ b/internal/app/tfsec/rules/gcp012.go
@@ -54,9 +54,10 @@ func init() {
 				"https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa",
 			},
 		},
-		Provider:       provider.GCPProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"google_container_cluster", "google_container_node_pool"},
+		Provider:        provider.GCPProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"google_container_cluster", "google_container_node_pool"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if strings.HasPrefix(resourceBlock.Label(), "google_container_cluster") && resourceBlock.GetAttribute("remove_default_node_pool").IsTrue() {

--- a/internal/app/tfsec/rules/gen001.go
+++ b/internal/app/tfsec/rules/gen001.go
@@ -67,8 +67,9 @@ func init() {
 				"https://www.terraform.io/docs/state/sensitive-data.html",
 			},
 		},
-		Provider:      provider.GeneralProvider,
-		RequiredTypes: []string{"variable"},
+		Provider:        provider.GeneralProvider,
+		RequiredTypes:   []string{"variable"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			if len(resourceBlock.Labels()) == 0 || !security.IsSensitiveAttribute(resourceBlock.TypeLabel()) {

--- a/internal/app/tfsec/rules/gen002.go
+++ b/internal/app/tfsec/rules/gen002.go
@@ -65,8 +65,9 @@ func init() {
 				"https://www.terraform.io/docs/state/sensitive-data.html",
 			},
 		},
-		Provider:      provider.GeneralProvider,
-		RequiredTypes: []string{"locals"},
+		Provider:        provider.GeneralProvider,
+		RequiredTypes:   []string{"locals"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			for _, attribute := range resourceBlock.GetAttributes() {

--- a/internal/app/tfsec/rules/gen003.go
+++ b/internal/app/tfsec/rules/gen003.go
@@ -87,8 +87,9 @@ func init() {
 				"https://www.terraform.io/docs/state/sensitive-data.html",
 			},
 		},
-		Provider:      provider.GeneralProvider,
-		RequiredTypes: []string{"resource", "provider", "module"},
+		Provider:        provider.GeneralProvider,
+		RequiredTypes:   []string{"resource", "provider", "module"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			attributes := resourceBlock.GetAttributes()

--- a/internal/app/tfsec/rules/gen004.go
+++ b/internal/app/tfsec/rules/gen004.go
@@ -69,9 +69,10 @@ func init() {
 				"https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository",
 			},
 		},
-		Provider:       provider.GeneralProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"github_repository"},
+		Provider:        provider.GeneralProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"github_repository"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 
 			privateAttribute := resourceBlock.GetAttribute("private")

--- a/internal/app/tfsec/rules/oci001.go
+++ b/internal/app/tfsec/rules/oci001.go
@@ -54,9 +54,10 @@ func init() {
 				"https://registry.terraform.io/providers/hashicorp/opc/latest/docs/resources/opc_compute_instance",
 			},
 		},
-		Provider:       provider.OracleProvider,
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"opc_compute_ip_address_reservation"},
+		Provider:        provider.OracleProvider,
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"opc_compute_ip_address_reservation"},
+		DefaultSeverity: severity.Warning,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if attr := resourceBlock.GetAttribute("ip_address_pool"); attr != nil {
 				if attr.IsAny("public-ippool") {

--- a/internal/app/tfsec/scanner/scanner.go
+++ b/internal/app/tfsec/scanner/scanner.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tfsec/tfsec/pkg/severity"
-
 	"github.com/tfsec/tfsec/pkg/result"
 
 	"github.com/tfsec/tfsec/internal/app/tfsec/block"
@@ -66,7 +64,7 @@ func (scanner *Scanner) Scan(blocks []*block.Block) []result.Result {
 					ruleResults := rule.CheckRule(r, checkBlock, context)
 					if scanner.includePassed && ruleResults.All() == nil {
 						res := result.New(checkBlock).WithRuleID(r.ID).WithDescription(fmt.Sprintf("Resource '%s' passed check: %s", checkBlock.FullName(), r.Documentation.Summary)).
-							WithRange(checkBlock.Range()).WithStatus(result.Passed).WithSeverity(severity.None)
+							WithRange(checkBlock.Range()).WithStatus(result.Passed).WithSeverity(r.DefaultSeverity)
 						results = append(results, *res)
 					} else if ruleResults != nil {
 						for _, ruleResult := range ruleResults.All() {
@@ -122,7 +120,7 @@ func (scanner *Scanner) checkRangeIgnored(id string, r block.Range, b block.Rang
 		line := lines[b.StartLine-1]
 		if strings.Contains(line, ignoreAll) || strings.Contains(line, ignoreCode) {
 			foundValidIgnore = true
-			lineValidIgnoreFound = b.StartLine-1
+			lineValidIgnoreFound = b.StartLine - 1
 		}
 	}
 
@@ -132,7 +130,7 @@ func (scanner *Scanner) checkRangeIgnored(id string, r block.Range, b block.Rang
 		if indexExpFound := strings.Index(lineWithPotentialExp, expWithCode); indexExpFound > 0 {
 			debug.Log("Expiration date found on ignore '%s'", lineWithPotentialExp)
 			layout := fmt.Sprintf("%s2006-01-02", expWithCode)
-			expDate := lineWithPotentialExp[indexExpFound:indexExpFound+len(layout)]
+			expDate := lineWithPotentialExp[indexExpFound : indexExpFound+len(layout)]
 			parsedDate, err := time.Parse(layout, expDate)
 
 			if err != nil {

--- a/internal/app/tfsec/test/ignore_test.go
+++ b/internal/app/tfsec/test/ignore_test.go
@@ -68,8 +68,9 @@ resource "aws_security_group_rule" "my-rule" {
 func Test_IgnoreSpecific(t *testing.T) {
 
 	scanner.RegisterCheckRule(rule.Rule{
-		ID:             "ABC123",
-		RequiredLabels: []string{"bad"},
+		ID:              "ABC123",
+		RequiredLabels:  []string{"bad"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			set.Add(
 				result.New(resourceBlock).WithDescription("example problem").WithRange(resourceBlock.Range()).WithSeverity(severity.Error),
@@ -78,8 +79,9 @@ func Test_IgnoreSpecific(t *testing.T) {
 	})
 
 	scanner.RegisterCheckRule(rule.Rule{
-		ID:             "DEF456",
-		RequiredLabels: []string{"bad"},
+		ID:              "DEF456",
+		RequiredLabels:  []string{"bad"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			set.Add(
 				result.New(resourceBlock).WithDescription("example problem").WithRange(resourceBlock.Range()).WithSeverity(severity.Error),

--- a/internal/app/tfsec/test/setup_test.go
+++ b/internal/app/tfsec/test/setup_test.go
@@ -47,8 +47,9 @@ resource "problem" "x" {
 `,
 			Links: nil,
 		},
-		RequiredTypes:  []string{"resource"},
-		RequiredLabels: []string{"problem"},
+		RequiredTypes:   []string{"resource"},
+		RequiredLabels:  []string{"problem"},
+		DefaultSeverity: severity.Error,
 		CheckFunc: func(set result.Set, resourceBlock *block.Block, _ *hclcontext.Context) {
 			if resourceBlock.GetAttribute("bad") != nil {
 				set.Add(

--- a/internal/app/tfsec/test/wildcard_test.go
+++ b/internal/app/tfsec/test/wildcard_test.go
@@ -59,9 +59,10 @@ func Test_WildcardMatchingOnRequiredLabels(t *testing.T) {
 			Documentation: rule.RuleDocumentation{
 				Summary: "blah",
 			},
-			Provider:       "custom",
-			RequiredTypes:  []string{"resource"},
-			RequiredLabels: []string{test.pattern},
+			Provider:        "custom",
+			RequiredTypes:   []string{"resource"},
+			RequiredLabels:  []string{test.pattern},
+			DefaultSeverity: severity.Error,
 			CheckFunc: func(set result.Set, rootBlock *block.Block, ctx *hclcontext.Context) {
 				set.Add(
 					result.New(rootBlock).WithDescription(fmt.Sprintf("Custom check failed for resource %s.", rootBlock.FullName())).

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -3,6 +3,7 @@ package rule
 import (
 	"github.com/tfsec/tfsec/pkg/provider"
 	"github.com/tfsec/tfsec/pkg/result"
+	"github.com/tfsec/tfsec/pkg/severity"
 
 	"github.com/tfsec/tfsec/internal/app/tfsec/block"
 	"github.com/tfsec/tfsec/internal/app/tfsec/hclcontext"
@@ -11,12 +12,13 @@ import (
 // Rule is a targeted security test which can be applied to terraform templates. It includes the types to run on e.g.
 // "resource", and the labels to run on e.g. "aws_s3_bucket".
 type Rule struct {
-	ID             string
-	Documentation  RuleDocumentation
-	Provider       provider.Provider
-	RequiredTypes  []string
-	RequiredLabels []string
-	CheckFunc      func(result.Set, *block.Block, *hclcontext.Context)
+	ID              string
+	Documentation   RuleDocumentation
+	Provider        provider.Provider
+	RequiredTypes   []string
+	RequiredLabels  []string
+	DefaultSeverity severity.Severity
+	CheckFunc       func(result.Set, *block.Block, *hclcontext.Context)
 }
 
 type RuleDocumentation struct {


### PR DESCRIPTION
When creating passed results, set the severity to the default severity of the rule.

If the user has a config that overrides severity, this will still take effect in the output

Resolves #810
