### PR TITLE
Support pushdown of module ignores

### DIFF
--- a/example/moduleWithIgnore/main.tf
+++ b/example/moduleWithIgnore/main.tf
@@ -1,0 +1,26 @@
+#tfsec:ignore:AWS052:exp:2021-02-02
+module "db" {
+  source = "terraform-aws-modules/rds/aws"
+  version = "~> 2.0"
+
+  identifier = "demodb"
+
+  engine            = "mysql"
+  engine_version    = "5.7.19"
+  instance_class    = "db.t2.large"
+  allocated_storage = 5
+
+  name     = "demodb"
+  username = "user"
+  password = aws_ssm_parameter.pw.value
+  port     = "3306"
+
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
+}
+
+resource "aws_ssm_parameter" "pw" {
+  name = "pw"
+  type = "SecureString"
+  value = "changeme"
+}

--- a/internal/app/tfsec/block/block.go
+++ b/internal/app/tfsec/block/block.go
@@ -34,6 +34,13 @@ func (block *Block) HasModuleBlock() bool {
 	return block.moduleBlock != nil
 }
 
+func (block *Block) GetModuleBlock() (*Block, error) {
+	if block.HasModuleBlock() {
+		return block.moduleBlock, nil
+	}
+	return nil, fmt.Errorf("the block does not have an associated module block")
+}
+
 func (block *Block) body() *hclsyntax.Body {
 	return block.hclBlock.Body.(*hclsyntax.Body)
 }


### PR DESCRIPTION
when the top-level module has an ignore code above it, any resources in
that module which fails the check will be ignored.

This will include nested modules

Resolve #493 