### PR TITLE
Add gocyclo, vet and misspell to the build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,11 @@ jobs:
         go-version: '1.16.4' # The Go version to download (if necessary) and use.
     - run: go version
 
-    - name: Run documentaion Linter
+    - name: Run Documentation Linter
       run: make lint-pr-checks
  
     - name: Run test
       run: make test
+
+    - name: Code Quality
+      run: make quality

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ cyclo:
 vet:
 	go vet ./...
 
-.PHONY: make typos
+.PHONY: typos
 typos:
 	./scripts/typos.sh
 
@@ -57,4 +57,4 @@ quality: cyclo vet typos
 .PHONY: fix-typos
 fix-typos:
 	./scripts/typos.sh fix
-	
+

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,24 @@ tagger:
 	@git pull origin master
 	@git tag -a ${TAG} -m ${TAG}
 	@git push --tags
+
+.PHONY: cyclo
+cyclo:
+	which gocyclo || go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+	gocyclo -over 15 -ignore 'vendor/|funcs/' .
+
+.PHONY: vet
+vet:
+	go vet ./...
+
+.PHONY: make typos
+typos:
+	./scripts/typos.sh
+
+.PHONY: quality
+quality: cyclo vet typos
+
+.PHONY: fix-typos
+fix-typos:
+	./scripts/typos.sh fix
+	

--- a/internal/app/tfsec/block/hclattribute.go
+++ b/internal/app/tfsec/block/hclattribute.go
@@ -298,21 +298,26 @@ func (attr *HCLAttribute) IsEmpty() bool {
 		return false
 	}
 	if attr.Value().IsNull() {
-		switch t := attr.hclAttribute.Expr.(type) {
-		case *hclsyntax.FunctionCallExpr, *hclsyntax.ScopeTraversalExpr,
-			*hclsyntax.ConditionalExpr, *hclsyntax.LiteralValueExpr:
-			return false
-		case *hclsyntax.TemplateExpr:
-			// walk the parts of the expression to ensure that it has a literal value
-			for _, p := range t.Parts {
-				switch pt := p.(type) {
-				case *hclsyntax.LiteralValueExpr:
-					if pt != nil && !pt.Val.IsNull() {
-						return false
-					}
-				case *hclsyntax.ScopeTraversalExpr:
+		return attr.isNullAttributeEmpty()
+	}
+	return true
+}
+
+func (attr *HCLAttribute) isNullAttributeEmpty() bool {
+	switch t := attr.hclAttribute.Expr.(type) {
+	case *hclsyntax.FunctionCallExpr, *hclsyntax.ScopeTraversalExpr,
+		*hclsyntax.ConditionalExpr, *hclsyntax.LiteralValueExpr:
+		return false
+	case *hclsyntax.TemplateExpr:
+		// walk the parts of the expression to ensure that it has a literal value
+		for _, p := range t.Parts {
+			switch pt := p.(type) {
+			case *hclsyntax.LiteralValueExpr:
+				if pt != nil && !pt.Val.IsNull() {
 					return false
 				}
+			case *hclsyntax.ScopeTraversalExpr:
+				return false
 			}
 		}
 	}

--- a/internal/app/tfsec/funcs/crypto.go
+++ b/internal/app/tfsec/funcs/crypto.go
@@ -120,7 +120,7 @@ var BcryptFunc = function.New(&function.Spec{
 		input := args[0].AsString()
 		out, err := bcrypt.GenerateFromPassword([]byte(input), defaultCost)
 		if err != nil {
-			return cty.UnknownVal(cty.String), fmt.Errorf("error occured generating password %s", err.Error())
+			return cty.UnknownVal(cty.String), fmt.Errorf("error occurred generating password %s", err.Error())
 		}
 
 		return cty.StringVal(string(out)), nil

--- a/internal/app/tfsec/funcs/string.go
+++ b/internal/app/tfsec/funcs/string.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ReplaceFunc constructs a function that searches a given string for another
-// given substring, and replaces each occurence with a given replacement string.
+// given substring, and replaces each occurrence with a given replacement string.
 var ReplaceFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{
@@ -48,7 +48,7 @@ var ReplaceFunc = function.New(&function.Spec{
 })
 
 // Replace searches a given string for another given substring,
-// and replaces all occurences with a given replacement string.
+// and replaces all occurrences with a given replacement string.
 func Replace(str, substr, replace cty.Value) (cty.Value, error) {
 	return ReplaceFunc.Call([]cty.Value{str, substr, replace})
 }

--- a/internal/app/tfsec/rules/aws013.go
+++ b/internal/app/tfsec/rules/aws013.go
@@ -98,7 +98,7 @@ func init() {
 				}
 
 				if err := json.Unmarshal(rawJSON, &definitions); err != nil {
-					debug.Log("an error occured processing container definition json: %s: %s", resourceBlock.Range(), err.Error())
+					debug.Log("an error occurred processing container definition json: %s: %s", resourceBlock.Range(), err.Error())
 					return
 				}
 

--- a/internal/app/tfsec/rules/aws021.go
+++ b/internal/app/tfsec/rules/aws021.go
@@ -21,7 +21,7 @@ import (
 
 const AWSCloudFrontOutdatedProtocol = "AWS021"
 const AWSCloudFrontOutdatedProtocolDescription = "CloudFront distribution uses outdated SSL/TLS protocols."
-const AWSCloudFrontOutdatedProtocolImpact = "Outdated SSL policies increase exposure to known vulnerabilites"
+const AWSCloudFrontOutdatedProtocolImpact = "Outdated SSL policies increase exposure to known vulnerabilities"
 const AWSCloudFrontOutdatedProtocolResolution = "Use the most modern TLS/SSL policies available"
 const AWSCloudFrontOutdatedProtocolExplanation = `
 You should not use outdated/insecure TLS versions for encryption. You should be using TLS v1.2+.

--- a/internal/app/tfsec/rules/aws025.go
+++ b/internal/app/tfsec/rules/aws025.go
@@ -21,7 +21,7 @@ import (
 
 const AWSApiGatewayDomainNameOutdatedSecurityPolicy = "AWS025"
 const AWSApiGatewayDomainNameOutdatedSecurityPolicyDescription = "API Gateway domain name uses outdated SSL/TLS protocols."
-const AWSApiGatewayDomainNameOutdatedSecurityPolicyImpact = "Outdated SSL policies increase exposure to known vulnerabilites"
+const AWSApiGatewayDomainNameOutdatedSecurityPolicyImpact = "Outdated SSL policies increase exposure to known vulnerabilities"
 const AWSApiGatewayDomainNameOutdatedSecurityPolicyResolution = "Use the most modern TLS/SSL policies available"
 const AWSApiGatewayDomainNameOutdatedSecurityPolicyExplanation = `
 You should not use outdated/insecure TLS versions for encryption. You should be using TLS v1.2+.
@@ -62,7 +62,7 @@ func init() {
 			if securityPolicyAttr == nil {
 				set.Add(
 					result.New(resourceBlock).
-						WithDescription(fmt.Sprintf("Resource '%s' should include security_policy (defauls to outdated SSL/TLS policy).", resourceBlock.FullName())).
+						WithDescription(fmt.Sprintf("Resource '%s' should include security_policy (defaults to outdated SSL/TLS policy).", resourceBlock.FullName())).
 						WithRange(resourceBlock.Range()).
 						WithSeverity(severity.Error),
 				)

--- a/internal/app/tfsec/rules/aws034.go
+++ b/internal/app/tfsec/rules/aws034.go
@@ -21,7 +21,7 @@ import (
 
 const AWSOutdatedTLSPolicyElasticsearchDomainEndpoint = "AWS034"
 const AWSOutdatedTLSPolicyElasticsearchDomainEndpointDescription = "Elasticsearch domain endpoint is using outdated TLS policy."
-const AWSOutdatedTLSPolicyElasticsearchDomainEndpointImpact = "Outdated SSL policies increase exposure to known vulnerabilites"
+const AWSOutdatedTLSPolicyElasticsearchDomainEndpointImpact = "Outdated SSL policies increase exposure to known vulnerabilities"
 const AWSOutdatedTLSPolicyElasticsearchDomainEndpointResolution = "Use the most modern TLS/SSL policies available"
 const AWSOutdatedTLSPolicyElasticsearchDomainEndpointExplanation = `
 You should not use outdated/insecure TLS versions for encryption. You should be using TLS v1.2+.

--- a/internal/app/tfsec/rules/aws053.go
+++ b/internal/app/tfsec/rules/aws053.go
@@ -18,7 +18,7 @@ import (
 )
 
 const AWSRDSPerformanceInsughtsEncryptionNotEnabled = "AWS053"
-const AWSRDSPerformanceInsughtsEncryptionNotEnabledDescription = "Encryption for RDS Perfomance Insights should be enabled."
+const AWSRDSPerformanceInsughtsEncryptionNotEnabledDescription = "Encryption for RDS Performance Insights should be enabled."
 const AWSRDSPerformanceInsughtsEncryptionNotEnabledImpact = "Data can be read from the RDS Performance Insights if it is compromised"
 const AWSRDSPerformanceInsughtsEncryptionNotEnabledResolution = "Enable encryption for RDS clusters and instances"
 const AWSRDSPerformanceInsughtsEncryptionNotEnabledExplanation = `

--- a/internal/app/tfsec/rules/aws086.go
+++ b/internal/app/tfsec/rules/aws086.go
@@ -22,7 +22,7 @@ const AWSDynamoDBRecoveryEnabledDescription = "Point in time recovery should be 
 const AWSDynamoDBRecoveryEnabledImpact = "Accidental or malicious writes and deletes can't be rolled back"
 const AWSDynamoDBRecoveryEnabledResolution = "Enable point in time recovery"
 const AWSDynamoDBRecoveryEnabledExplanation = `
-DynamoDB tables should be protected against accidently or malicious write/delete actions by ensuring that there is adaquate protection.
+DynamoDB tables should be protected against accidentally or malicious write/delete actions by ensuring that there is adaquate protection.
 
 By enabling point-in-time-recovery you can restore to a known point in the event of loss of data.
 `

--- a/internal/app/tfsec/rules/aws095.go
+++ b/internal/app/tfsec/rules/aws095.go
@@ -22,7 +22,7 @@ const AWSSecretsManagerSecretEncryptionDescription = "Secrets Manager should use
 const AWSSecretsManagerSecretEncryptionImpact = "Using AWS managed keys reduces the flexibility and control over the encryption key"
 const AWSSecretsManagerSecretEncryptionResolution = "Use customer managed keys"
 const AWSSecretsManagerSecretEncryptionExplanation = `
-Secrets Manager encrypts secrets by default using a default key created by AWS. To ensure control and granularity of secret encryption, CMK's should be used explictly.
+Secrets Manager encrypts secrets by default using a default key created by AWS. To ensure control and granularity of secret encryption, CMK's should be used explicitly.
 `
 const AWSSecretsManagerSecretEncryptionBadExample = `
 resource "aws_secretsmanager_secret" "bad_example" {

--- a/internal/app/tfsec/rules/azu014.go
+++ b/internal/app/tfsec/rules/azu014.go
@@ -20,7 +20,7 @@ import (
 const AZURequireSecureTransferForStorageAccounts = "AZU014"
 const AZURequireSecureTransferForStorageAccountsDescription = "Storage accounts should be configured to only accept transfers that are over secure connections"
 const AZURequireSecureTransferForStorageAccountsImpact = "Insecure transfer of data into secure accounts could be read if intercepted"
-const AZURequireSecureTransferForStorageAccountsResolution = "Only allow secure connection for transfering data into storage accounts"
+const AZURequireSecureTransferForStorageAccountsResolution = "Only allow secure connection for transferring data into storage accounts"
 const AZURequireSecureTransferForStorageAccountsExplanation = `
 You can configure your storage account to accept requests from secure connections only by setting the Secure transfer required property for the storage account. 
 

--- a/internal/app/tfsec/rules/dig007.go
+++ b/internal/app/tfsec/rules/dig007.go
@@ -17,7 +17,7 @@ const DIGForceDestroyEnabledDescription = "Force destroy is enabled on Spaces bu
 const DIGForceDestroyEnabledImpact = "Accidental deletion of bucket objects"
 const DIGForceDestroyEnabledResolution = "Don't use force destroy on bucket configuration"
 const DIGForceDestroyEnabledExplanation = `
-Enabling force destroy on a Spaces bucket means that the bucket can be deleted without the additional check that it is empty. This risks important data being accidently deleted by a bucket removal process.
+Enabling force destroy on a Spaces bucket means that the bucket can be deleted without the additional check that it is empty. This risks important data being accidentally deleted by a bucket removal process.
 `
 const DIGForceDestroyEnabledBadExample = `
 resource "digitalocean_spaces_bucket" "bad_example" {

--- a/internal/app/tfsec/scanner/scanner.go
+++ b/internal/app/tfsec/scanner/scanner.go
@@ -180,7 +180,7 @@ func traverseModuleTree(b block.Block, ignoreAll, ignoreCode string) (bool, stri
 	if b.HasModuleBlock() {
 		moduleBlock, err := b.GetModuleBlock()
 		if err != nil {
-			debug.Log("error occured trying to get the module block for [%s]. %s", b.FullName(), err.Error())
+			debug.Log("error occurred trying to get the module block for [%s]. %s", b.FullName(), err.Error())
 			return false, ""
 		}
 		moduleLines, err := readLines(moduleBlock.Range().Filename)

--- a/internal/app/tfsec/test/azu003_test.go
+++ b/internal/app/tfsec/test/azu003_test.go
@@ -23,7 +23,7 @@ resource "azurerm_managed_disk" "my-disk" {
 			mustExcludeResultCode: rules.AzureUnencryptedManagedDisk,
 		},
 		{
-			name: "check azurerm_managed_disk with encryption disabled",
+			name: "check azurerm_manaaged_disk with encryption disabled",
 			source: `
 resource "azurerm_managed_disk" "my-disk" {
 	encryption_settings {

--- a/internal/app/tfsec/test/azu003_test.go
+++ b/internal/app/tfsec/test/azu003_test.go
@@ -23,7 +23,7 @@ resource "azurerm_managed_disk" "my-disk" {
 			mustExcludeResultCode: rules.AzureUnencryptedManagedDisk,
 		},
 		{
-			name: "check azurerm_manaaged_disk with encryption disabled",
+			name: "check azurerm_managed_disk with encryption disabled",
 			source: `
 resource "azurerm_managed_disk" "my-disk" {
 	encryption_settings {

--- a/scripts/typos.sh
+++ b/scripts/typos.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+highlight="\x1b[31m"
+if [[ "$1" == "fix" ]]; then
+    fix="-w"
+    highlight="\x1b[32m"
+fi
+
+trim() {
+    local var="$*"
+    # remove leading whitespace characters
+    var="${var#"${var%%[![:space:]]*}"}" 
+    printf '%s' "$var"
+}
+
+which misspell || go install github.com/client9/misspell/cmd/misspell
+fixes=$(find . -type f | grep -v vendor/ | grep -v funcs/ | xargs misspell -error $fix)
+
+[[ "$?" == "0" ]] && echo -e "\x1b[32mNo typos!\x1b[0m" && exit 0
+
+count=$(echo "$fixes" | wc -l)
+
+echo "$fixes" | while read fix; do
+    file=$(echo $fix | awk -F':' '{print $1}')
+    lineno=$(echo $fix | awk -F':' '{print $2}')
+    column=$(echo $fix | awk -F':' '{print $3}')
+    info=$(echo $fix | awk -F':' '{print $4}')
+    line=$(sed "${lineno}q;d" $file)
+    before=${line:0:$column}
+    rest=${line:$column}
+    typo=$(echo $rest | awk -F'[\(\[\]\)\":., ]' '{print $1}')
+    endpos=$(echo "$before$typo" | wc -c)
+    endpos=$(($endpos - 1))
+    after=${line:$endpos}
+    before=$(trim "$before")
+    echo
+    echo "$file:$lineno:$column"
+    echo -e "\$highlight$info:\x1b[0m"
+    echo -e " $before$highlight$typo\x1b[0m$after"
+    echo
+done
+
+if [[ "$1" == "fix" ]]; then
+    echo
+    echo -e "\x1b[32mAll typos fixed!\x1b[0m"
+    echo
+else
+    echo
+    echo -e "\x1b[31mFound $count typo(s). Fix them all with 'make fix-typos'.\x1b[0m"
+    echo
+fi


### PR DESCRIPTION
You can run these locally with `make quality`.

You can also `make typos` to see any typos, and `make fix-typos` to autocorrect them.